### PR TITLE
fix reuse of certificate secret with same name in different namespace

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -484,7 +484,7 @@ func (r *certReconciler) findSecretByHashLabel(specHash string) (*corev1.SecretR
 }
 
 func (r *certReconciler) copySecretIfNeeded(objectMeta metav1.ObjectMeta, secretRef *corev1.SecretReference, specHash string, secretName *string) (*corev1.SecretReference, error) {
-	if secretName == nil || secretRef.Name == *secretName {
+	if secretName == nil || (secretRef.Name == *secretName && core.NormalizeNamespace(secretRef.Namespace) == core.NormalizeNamespace(objectMeta.Namespace)) {
 		return secretRef, nil
 	}
 	secret, err := r.loadSecret(secretRef)
@@ -498,11 +498,8 @@ func (r *certReconciler) copySecretIfNeeded(objectMeta metav1.ObjectMeta, secret
 func (r *certReconciler) writeCertificateSecret(objectMeta metav1.ObjectMeta, certificates *certificate.Resource,
 	specHash string, secretName *string) (*corev1.SecretReference, error) {
 	secret := &corev1.Secret{}
-	if objectMeta.GetNamespace() != "" {
-		secret.SetNamespace(objectMeta.GetNamespace())
-	} else {
-		secret.SetNamespace("default")
-	}
+	namespace := core.NormalizeNamespace(objectMeta.GetNamespace())
+	secret.SetNamespace(namespace)
 	if secretName != nil {
 		secret.SetName(*secretName)
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
If a certificate is reused with the same name in a second namespace,
it must be copied to the second namespace.

**Which issue(s) this PR fixes**:
Fixes #2


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
bug fix: create secret copy if two managed ingress with same TLS hosts and same secret name are defined in two namespaces (issue #2)
```
