### PR TITLE
fix multiple DNS challenges for same domain name

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -265,7 +265,7 @@ func (r *certReconciler) obtainCertificateAndPending(logger logger.LogContext, o
 		dnsSettings.Namespace = *r.dnsNamespace
 	}
 	targetClass := r.getAnnotatedClass(obj)
-	input := legobridge.ObtainInput{User: reguser, DNSCluster: r.dnsCluster, DNSSettings: dnsSettings,
+	input := legobridge.ObtainInput{Logger: logger, User: reguser, DNSCluster: r.dnsCluster, DNSSettings: dnsSettings,
 		CaDirURL: server, IssuerName: r.issuerName(&cert.Spec),
 		CommonName: cert.Spec.CommonName, DNSNames: cert.Spec.DNSNames, CSR: cert.Spec.CSR,
 		TargetClass: targetClass, Callback: callback, RequestName: objectName, RenewCert: renewCert}


### PR DESCRIPTION
**What this PR does / why we need it**:
If certificate is requested for DNS names like `mydomain.com` and `*.mydomain.com`, two DNS challenges are created for `mydomain.com` which need to be presented in a single TXT DNS record.
Additionally, this PR improves the robustness and speed of the DNS challenge validation by waiting for readiness of DNS entries.

**Which issue(s) this PR fixes**:
Fixes #3

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
fix multiple DNS challenges for same domain name.
```

```improvement user
wait for readiness of DNSEntries before starting DNS challenge validation. 
```
