### PR TITLE
fix panic if an ingress spec does not provide tls hosts

### DIFF
--- a/examples/40-ingress-echoheaders.yaml
+++ b/examples/40-ingress-echoheaders.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: echoheaders
   namespace: default
-  annotation:
+  annotations:
     cert.gardener.cloud/purpose: managed
 spec:
   tls:

--- a/pkg/cert/source/reconciler.go
+++ b/pkg/cert/source/reconciler.go
@@ -311,7 +311,7 @@ func (this *sourceReconciler) createEntryFor(logger logger.LogContext, obj resou
 	if this.targetclass != "" {
 		resources.SetAnnotation(cert, ANNOT_CLASS, this.targetclass)
 	}
-	if len(info.Domains) >= 0 {
+	if len(info.Domains) > 0 {
 		cert.Spec.CommonName = &info.Domains[0]
 		cert.Spec.DNSNames = info.Domains[1:]
 	}
@@ -371,7 +371,7 @@ func (this *sourceReconciler) updateEntry(logger logger.LogContext, info CertInf
 		mod.Modify(changed)
 		var cn *string
 		var dnsNames []string
-		if len(info.Domains) >= 0 {
+		if len(info.Domains) > 0 {
 			cn = &info.Domains[0]
 			dnsNames = info.Domains[1:]
 		}


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #6 

**Release note**:
```improvement operator
fix for "Panic if ingress spec.tls.hosts not specified" (issue #6)
```