### PR TITLE
adding command line option --dns-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Flags:
       --default-issuer-domain-ranges string                default for all controller "default-issuer-domain-ranges" options
       --disable-namespace-restriction                      disable access restriction for namespace local access only
       --dns string                                         cluster for writing challenge DNS entries
+      --dns-class string                                   default for all controller "dns-class" options
       --dns-namespace string                               default for all controller "dns-namespace" options
       --dns-owner-id string                                default for all controller "dns-owner-id" options
       --dns.disable-deploy-crds                            disable deployment of required crds for cluster dns
@@ -358,6 +359,7 @@ Flags:
       --issuer.default-issuer-domain-ranges string         domain range restrictions when using default issuer separated by comma
       --issuer.default.pool.resync-period duration         Period for resynchronization of pool default of controller issuer (default: 24h0m0s)
       --issuer.default.pool.size int                       Worker pool size for pool default of controller issuer (default: 2)
+      --issuer.dns-class string                            class for creating challenge DNSEntries (in DNS cluster)
       --issuer.dns-namespace string                        namespace for creating challenge DNSEntries (in DNS cluster)
       --issuer.dns-owner-id string                         ownerId for creating challenge DNSEntries
       --issuer.issuer-namespace string                     namespace to lookup issuers on default cluster

--- a/charts/cert-management/values.yaml
+++ b/charts/cert-management/values.yaml
@@ -34,6 +34,7 @@ configuration:
 # defaultIssuerDomainRange:
 # disableNamespaceRestriction:
 # dns:
+# dnsClass:
 # dnsNamespace:
 # dnsOwnerId:
 # dnsId:
@@ -50,6 +51,7 @@ configuration:
 # issuerDefaultIssuerDomainRange:
 # issuerDefaultPoolResyncPeriod:
 # issuerDefaultPoolSize:
+# issuerDnsClass:
 # issuerDnsNamespace:
 # issuerDnsOwnerId:
 # issuerIssuerNamespace:

--- a/pkg/cert/legobridge/dnscontrollerprovider.go
+++ b/pkg/cert/legobridge/dnscontrollerprovider.go
@@ -118,7 +118,9 @@ func (p *dnsControllerProvider) Present(domain, token, keyAuth string) error {
 		e.Spec.OwnerId = p.settings.OwnerID
 		e.Spec.TTL = &p.ttl
 		e.Spec.Text = values
-		resources.SetAnnotation(e, source.AnnotClass, p.targetClass)
+		if p.targetClass != "" {
+			resources.SetAnnotation(e, source.AnnotDNSClass, p.targetClass)
+		}
 	}
 
 	entry := p.prepareEntry(domain)

--- a/pkg/cert/source/controller.go
+++ b/pkg/cert/source/controller.go
@@ -32,6 +32,8 @@ import (
 const (
 	// AnnotDnsnames annotation is shared with dns controller manager
 	AnnotDnsnames = "dns.gardener.cloud/dnsnames"
+	// AnnotDNSClass is the annotation for the dns class
+	AnnotDNSClass = "dns.gardener.cloud/class"
 	// AnnotClass is the annotation for the cert class
 	AnnotClass = "cert.gardener.cloud/class"
 	// AnnotForwardOwnerRefs is the annotation for the forward owner references

--- a/pkg/controller/issuer/controller.go
+++ b/pkg/controller/issuer/controller.go
@@ -36,6 +36,7 @@ func init() {
 		DefaultedStringOption(core.OptIssuerNamespace, "default", "namespace to lookup issuers on default cluster").
 		StringOption(core.OptDefaultIssuerDomainRanges, "domain range restrictions when using default issuer separated by comma").
 		StringOption(core.OptDNSNamespace, "namespace for creating challenge DNSEntries (in DNS cluster)").
+		StringOption(core.OptDNSClass, "class for creating challenge DNSEntries (in DNS cluster)").
 		StringOption(core.OptDNSOwnerID, "ownerId for creating challenge DNSEntries").
 		BoolOption(core.OptCascadeDelete, "If true, certificate secrets are deleted if dependent resources (certificate, ingress) are deleted").
 		StringOption(source.OptClass, "Identifier used to differentiate responsible controllers for entries").

--- a/pkg/controller/issuer/core/const.go
+++ b/pkg/controller/issuer/core/const.go
@@ -23,6 +23,8 @@ const (
 	OptIssuerNamespace = "issuer-namespace"
 	// OptDNSNamespace is the DNS namespace command line option.
 	OptDNSNamespace = "dns-namespace"
+	// OptDNSClass is the DNS class command line option.
+	OptDNSClass = "dns-class"
 	// OptDNSOwnerID is the DNS owner identifier command line option.
 	OptDNSOwnerID = "dns-owner-id"
 	// OptDefaultIssuerDomainRanges are the domain ranges the default issuer is restricted to.


### PR DESCRIPTION
**What this PR does / why we need it**:
If there are multiple dns-controller-manager running on the dns cluster,
the dns.gardener.cloud/class has to be set for the challenging dns entry to select the
correct dns-controller-manager.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
new command line option --dns-class to set the dns class for challenging dns entries optionally
```
