### PR TITLE
Enhance CRD validation

### DIFF
--- a/charts/cert-management/templates/crds.yaml
+++ b/charts/cert-management/templates/crds.yaml
@@ -196,6 +196,7 @@ spec:
           properties:
             commonName:
               description: CommonName is the CN for the certificate (max. 64 chars).
+              maxLength: 64
               type: string
             csr:
               description: CSR is the alternative way to provide CN,DNSNames and other

--- a/charts/cert-management/templates/crds.yaml
+++ b/charts/cert-management/templates/crds.yaml
@@ -29,22 +29,100 @@ spec:
     - JSONPath: .metadata.creationTimestamp
       name: AGE
       type: date
+  conversion:
+    strategy: None
   group: cert.gardener.cloud
+  subresources:
+    status: {}
   names:
     kind: Issuer
     listKind: IssuerList
     plural: issuers
+    singular: issuer
     shortNames:
       - issuer
-    singular: issuer
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true
       storage: true
+  validation:
+    openAPIV3Schema:
+      description: Issuer is the issuer CR.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the spec of the issuer.
+          properties:
+            acme:
+              description: ACME is the ACME protocol specific spec.
+              properties:
+                autoRegistration:
+                  description: AutoRegistration is the flag if automatic registration
+                    should be applied if needed.
+                  type: boolean
+                email:
+                  description: Email is the email address to use for user registration.
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKeySecretRef is the secret ref to the ACME private
+                    key.
+                  properties:
+                    name:
+                      description: Name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: Namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                server:
+                  description: Server is the URL of the ACME server.
+                  type: string
+              required:
+                - email
+                - server
+              type: object
+          type: object
+        status:
+          description: IssuerStatus is the status of the issuer.
+          properties:
+            acme:
+              description: ACME is the ACME specific status.
+              type: object
+            message:
+              description: Message is the status or error message.
+              type: string
+            observedGeneration:
+              description: ObservedGeneration is the observed generation of the spec.
+              format: int64
+              type: integer
+            state:
+              description: State is either empty, 'Pending', 'Error', or 'Ready'.
+              type: string
+            type:
+              description: Type is the issuer type. Currently only 'acme' is supported.
+              type: string
+          required:
+            - state
+            - type
+          type: object
+      required:
+        - spec
+      type: object
+  version: v1alpha1
 {{- end }}
 ---
 {{- if .Values.createCRDs.certificates }}
@@ -84,17 +162,128 @@ spec:
     - JSONPath: .metadata.creationTimestamp
       name: AGE
       type: date
+  conversion:
+    strategy: None
+  subresources:
+    status: {}
   group: cert.gardener.cloud
   names:
     kind: Certificate
     listKind: CertificateList
     plural: certificates
+    singular: certificate
     shortNames:
       - cert
-    singular: certificate
   scope: Namespaced
-  subresources:
-    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Certificate is the certificate CR.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateSpec is the spec of the certificate to request.
+          properties:
+            commonName:
+              description: CommonName is the CN for the certificate (max. 64 chars).
+              type: string
+            csr:
+              description: CSR is the alternative way to provide CN,DNSNames and other
+                information.
+              format: byte
+              type: string
+            dnsNames:
+              description: DNSNames are the optional additional domain names of the
+                certificate.
+              items:
+                type: string
+              type: array
+            issuerRef:
+              description: IssuerRef is the reference of the issuer to use.
+              properties:
+                name:
+                  description: Name is the name of the issuer CR in the same namespace.
+                  type: string
+              required:
+                - name
+              type: object
+            secretName:
+              description: SecretName is the name of the secret object to use for
+                storing the certificate.
+              type: string
+            secretRef:
+              description: SecretRef is the reference of the secret object to use
+                for storing the certificate.
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
+          type: object
+        status:
+          description: CertificateStatus is the status of the certificate request.
+          properties:
+            commonName:
+              description: CommonName is the current CN.
+              type: string
+            dnsNames:
+              description: DNSNames are the current domain names.
+              items:
+                type: string
+              type: array
+            expirationDate:
+              description: ExpirationDate shows the notAfter validity date.
+              type: string
+            issuerRef:
+              description: IssuerRef is the used issuer.
+              properties:
+                name:
+                  description: Name is the name of the issuer CR.
+                  type: string
+                namespace:
+                  description: Namespace is the namespace of the issuer CR.
+                  type: string
+              required:
+                - name
+                - namespace
+              type: object
+            lastPendingTimestamp:
+              description: LastPendingTimestamp contains the start timestamp of the
+                last pending status.
+              format: date-time
+              type: string
+            message:
+              description: Message is the status or error message.
+              type: string
+            observedGeneration:
+              description: ObservedGeneration is the observed generation of the spec.
+              format: int64
+              type: integer
+            state:
+              description: State is the certificate state.
+              type: string
+          required:
+            - lastPendingTimestamp
+            - state
+          type: object
+      required:
+        - spec
+      type: object
   version: v1alpha1
   versions:
     - name: v1alpha1

--- a/examples/10-crds.yaml
+++ b/examples/10-crds.yaml
@@ -184,6 +184,7 @@ spec:
           properties:
             commonName:
               description: CommonName is the CN for the certificate (max. 64 chars).
+              maxLength: 64
               type: string
             csr:
               description: CSR is the alternative way to provide CN,DNSNames and other

--- a/examples/10-crds.yaml
+++ b/examples/10-crds.yaml
@@ -118,12 +118,6 @@ spec:
         - spec
       type: object
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -166,6 +160,8 @@ spec:
     listKind: CertificateList
     plural: certificates
     singular: certificate
+    shortNames:
+      - cert
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -281,9 +277,3 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR harmonizes the CRD files in the examples and charts directories. It also adds a 64 char limit to the CRD validation for the `commonName` field. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `commonName` field of certificates is now subjected to a 64 characters limit.
```
