### PR TITLE
make propagation timeout configurable and use it for DNSEntry TTL

### DIFF
--- a/charts/cert-management/templates/deployment.yaml
+++ b/charts/cert-management/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
         {{- if .Values.configuration.defaultIssuerDomainRanges }}
         - --default-issuer-domain-ranges={{ .Values.configuration.defaultIssuerDomainRanges }}
         {{- end }}
+        {{- if .Values.configuration.defaultRequestsPerDayQuota }}
+        - --default-requests-per-day-quota={{ .Values.configuration.defaultRequestsPerDayQuota }}
+        {{- end }}
         {{- if .Values.configuration.disableNamespaceRestriction }}
         - --disable-namespace-restriction={{ .Values.configuration.disableNamespaceRestriction }}
         {{- end }}
@@ -111,6 +114,9 @@ spec:
         {{- if .Values.configuration.issuerDefaultIssuerDomainRanges }}
         - --issuer.default-issuer-domain-ranges={{ .Values.configuration.issuerDefaultIssuerDomainRanges }}
         {{- end }}
+        {{- if .Values.configuration.issuerDefaultRequestsPerDayQuota }}
+        - --issuer.default-requests-per-day-quota={{ .Values.configuration.issuerDefaultRequestsPerDayQuota }}
+        {{- end }}
         {{- if .Values.configuration.issuerDefaultPoolResyncPeriod }}
         - --issuer.default.pool.resync-period={{ .Values.configuration.issuerDefaultPoolResyncPeriod }}
         {{- end }}
@@ -137,6 +143,9 @@ spec:
         {{- end }}
         {{- if .Values.configuration.issuerPrecheckNameservers }}
         - --issuer.precheck-nameservers={{ .Values.configuration.issuerPrecheckNameservers }}
+        {{- end }}
+        {{- if .Values.configuration.issuerPropagationTimeout }}
+        - --issuer.propagation-timeout={{ .Values.configuration.issuerPropagationTimeout }}
         {{- end }}
         {{- if .Values.configuration.issuerRenewalWindow }}
         - --issuer.renewal-window={{ .Values.configuration.issuerRenewalWindow }}
@@ -174,11 +183,14 @@ spec:
         {{- if .Values.configuration.poolSize }}
         - --pool.size={{ .Values.configuration.poolSize }}
         {{- end }}
+        {{- if .Values.configuration.precheckAdditionalWait }}
+        - --precheck-additional-wait={{ .Values.configuration.precheckAdditionalWait }}
+        {{- end }}
         {{- if .Values.configuration.precheckNameservers }}
         - --precheck-nameservers={{ .Values.configuration.precheckNameservers }}
         {{- end }}
-        {{- if .Values.configuration.precheckAdditionalWait }}
-        - --precheck-additional-wait={{ .Values.configuration.precheckAdditionalWait }}
+        {{- if .Values.configuration.propagationTimeout }}
+        - --propagation-timeout={{ .Values.configuration.propagationTimeout }}
         {{- end }}
         {{- if .Values.configuration.renewalWindow }}
         - --renewal-window={{ .Values.configuration.renewalWindow }}

--- a/charts/cert-management/values.yaml
+++ b/charts/cert-management/values.yaml
@@ -33,6 +33,7 @@ configuration:
   # cpuprofile:
   # defaultIssuer:
   # defaultIssuerDomainRanges:
+  # defaultRequestsPerDayQuota:
   # disableNamespaceRestriction:
   # dns:
   # dnsClass:
@@ -53,6 +54,7 @@ configuration:
   # issuerCertClass:
   # issuerDefaultIssuer:
   # issuerDefaultIssuerDomainRanges:
+  # issuerDefaultRequestsPerDayQuota:
   # issuerDefaultPoolResyncPeriod:
   # issuerDefaultPoolSize:
   # issuerDnsClass:
@@ -62,6 +64,7 @@ configuration:
   # issuerIssuersPoolSize:
   # issuerPrecheckAdditionalWait:
   # issuerPrecheckNameservers:
+  # issuerPropagationTimeout:
   # issuerRenewalWindow:
   # issuerSecretsPoolSize:
   # kubeconfig:
@@ -74,8 +77,9 @@ configuration:
   # pluginDir:
   # poolResyncPeriod:
   # poolSize:
-  # precheckNameservers:
   # precheckAdditionalWait:
+  # precheckNameservers:
+  # propagationTimeout:
   # renewalWindow:
   serverPortHttp: 8080
   # serviceCertCertClass:
@@ -94,6 +98,4 @@ configuration:
   # targetDisableDeployCrds:
   # targetId:
 
-
 additionalConfiguration: []
-

--- a/hack/generateChartOptions.py
+++ b/hack/generateChartOptions.py
@@ -6,75 +6,79 @@
 import re
 
 options = """
-cascade-delete
-cert-class
-cert-target-class
-controllers
-cpuprofile
-default-issuer
-default-issuer-domain-ranges
-disable-namespace-restriction
-dns
-dns-class
-dns-namespace
-dns-owner-id
-dns.disable-deploy-crds
-dns.id
-grace-period
-help
-ingress-cert.cert-class
-ingress-cert.cert-target-class
-ingress-cert.default.pool.resync-period
-ingress-cert.default.pool.size
-ingress-cert.target-name-prefix
-ingress-cert.target-namespace
-ingress-cert.targets.pool.size
-issuer-namespace
-issuer.cascade-delete
-issuer.cert-class
-issuer.default-issuer
-issuer.default-issuer-domain-ranges
-issuer.default.pool.resync-period
-issuer.default.pool.size
-issuer.dns-class
-issuer.dns-namespace
-issuer.dns-owner-id
-issuer.issuer-namespace
-issuer.issuers.pool.size
-issuer.precheck-additional-wait
-issuer.precheck-nameservers
-issuer.renewal-window
-issuer.secrets.pool.size
-kubeconfig
-kubeconfig.disable-deploy-crds
-kubeconfig.id
-log-level
-name
-namespace
-namespace-local-access-only
-omit-lease
-plugin-dir
-pool.resync-period
-pool.size
-precheck-nameservers
-precheck-additional-wait
-renewal-window
-server-port-http
-service-cert.cert-class
-service-cert.cert-target-class
-service-cert.default.pool.resync-period
-service-cert.default.pool.size
-service-cert.target-name-prefix
-service-cert.target-namespace
-service-cert.targets.pool.size
-source
-source.disable-deploy-crds
-source.id
-target
-target-name-prefix
-target-namespace
-target.disable-deploy-crds
-target.id
+      --cascade-delete                                     default for all controller "cascade-delete" options
+      --cert-class string                                  default for all controller "cert-class" options
+      --cert-target-class string                           default for all controller "cert-target-class" options
+  -c, --controllers string                                 comma separated list of controllers to start (<name>,source,target,all) (default "all")
+      --cpuprofile string                                  set file for cpu profiling
+      --default-issuer string                              default for all controller "default-issuer" options
+      --default-issuer-domain-ranges string                default for all controller "default-issuer-domain-ranges" options
+      --default-requests-per-day-quota int                 default for all controller "default-requests-per-day-quota" options
+      --disable-namespace-restriction                      disable access restriction for namespace local access only
+      --dns string                                         cluster for writing challenge DNS entries
+      --dns-class string                                   default for all controller "dns-class" options
+      --dns-namespace string                               default for all controller "dns-namespace" options
+      --dns-owner-id string                                default for all controller "dns-owner-id" options
+      --dns.disable-deploy-crds                            disable deployment of required crds for cluster dns
+      --dns.id string                                      id for cluster dns
+      --grace-period duration                              inactivity grace period for detecting end of cleanup for shutdown
+  -h, --help                                               help for cert-controller-manager
+      --ingress-cert.cert-class string                     Identifier used to differentiate responsible controllers for entries
+      --ingress-cert.cert-target-class string              Identifier used to differentiate responsible dns controllers for target entries
+      --ingress-cert.default.pool.resync-period duration   Period for resynchronization of pool default of controller ingress-cert (default: 2m0s)
+      --ingress-cert.default.pool.size int                 Worker pool size for pool default of controller ingress-cert (default: 2)
+      --ingress-cert.target-name-prefix string             name prefix in target namespace for cross cluster generation
+      --ingress-cert.target-namespace string               target namespace for cross cluster generation
+      --ingress-cert.targets.pool.size int                 Worker pool size for pool targets of controller ingress-cert (default: 2)
+      --issuer-namespace string                            default for all controller "issuer-namespace" options
+      --issuer.cascade-delete                              If true, certificate secrets are deleted if dependent resources (certificate, ingress) are deleted
+      --issuer.cert-class string                           Identifier used to differentiate responsible controllers for entries
+      --issuer.default-issuer string                       name of default issuer (from default cluster)
+      --issuer.default-issuer-domain-ranges string         domain range restrictions when using default issuer separated by comma
+      --issuer.default-requests-per-day-quota int          Default value for requestsPerDayQuota if not set explicitly in the issuer spec.
+      --issuer.default.pool.resync-period duration         Period for resynchronization of pool default of controller issuer (default: 24h0m0s)
+      --issuer.default.pool.size int                       Worker pool size for pool default of controller issuer (default: 2)
+      --issuer.dns-class string                            class for creating challenge DNSEntries (in DNS cluster)
+      --issuer.dns-namespace string                        namespace for creating challenge DNSEntries (in DNS cluster)
+      --issuer.dns-owner-id string                         ownerId for creating challenge DNSEntries
+      --issuer.issuer-namespace string                     namespace to lookup issuers on default cluster
+      --issuer.issuers.pool.size int                       Worker pool size for pool issuers of controller issuer (default: 1)
+      --issuer.precheck-additional-wait duration           additional wait time after DNS propagation check
+      --issuer.precheck-nameservers string                 DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf
+      --issuer.propagation-timeout duration                propagation timeout for DNS challenge
+      --issuer.renewal-window duration                     certificate is renewed if its validity period is shorter
+      --issuer.secrets.pool.size int                       Worker pool size for pool secrets of controller issuer (default: 1)
+      --kubeconfig string                                  default cluster access
+      --kubeconfig.disable-deploy-crds                     disable deployment of required crds for cluster default
+      --kubeconfig.id string                               id for cluster default
+  -D, --log-level string                                   logrus log level
+      --name string                                        name used for controller manager
+      --namespace string                                   namespace for lease
+  -n, --namespace-local-access-only                        enable access restriction for namespace local access only (deprecated)
+      --omit-lease                                         omit lease for development
+      --plugin-dir string                                  directory containing go plugins
+      --pool.resync-period duration                        default for all controller "pool.resync-period" options
+      --pool.size int                                      default for all controller "pool.size" options
+      --precheck-additional-wait duration                  default for all controller "precheck-additional-wait" options
+      --precheck-nameservers string                        default for all controller "precheck-nameservers" options
+      --propagation-timeout duration                       default for all controller "propagation-timeout" options
+      --renewal-window duration                            default for all controller "renewal-window" options
+      --server-port-http int                               HTTP server port (serving /healthz, /metrics, ...)
+      --service-cert.cert-class string                     Identifier used to differentiate responsible controllers for entries
+      --service-cert.cert-target-class string              Identifier used to differentiate responsible dns controllers for target entries
+      --service-cert.default.pool.resync-period duration   Period for resynchronization of pool default of controller service-cert (default: 2m0s)
+      --service-cert.default.pool.size int                 Worker pool size for pool default of controller service-cert (default: 2)
+      --service-cert.target-name-prefix string             name prefix in target namespace for cross cluster generation
+      --service-cert.target-namespace string               target namespace for cross cluster generation
+      --service-cert.targets.pool.size int                 Worker pool size for pool targets of controller service-cert (default: 2)
+      --source string                                      source cluster to watch for ingresses and services
+      --source.disable-deploy-crds                         disable deployment of required crds for cluster source
+      --source.id string                                   id for cluster source
+      --target string                                      target cluster for certificates
+      --target-name-prefix string                          default for all controller "target-name-prefix" options
+      --target-namespace string                            default for all controller "target-namespace" options
+      --target.disable-deploy-crds                         disable deployment of required crds for cluster target
+      --target.id string                                   id for cluster target
 """
 
 def toCamelCase(name):
@@ -83,8 +87,11 @@ def toCamelCase(name):
   return str
 
 excluded = {"name", "help"}
-for name in options.split("\n"):
-    if name != "" and not name in excluded:
+for line in options.split("\n"):
+    m = re.match(r"\s+(?:-[^-]+)?--(\S+)\s", line)
+    if m:
+      name = m.group(1)
+      if name != "" and not name in excluded:
         camelCase = toCamelCase(name)
         txt = """        {{- if .Values.configuration.%s }}
         - --%s={{ .Values.configuration.%s }}
@@ -96,12 +103,16 @@ print("\n\n\n")
 defaultValues = {
   "serverPortHttp": "8080"
 }
+
 print("configuration:")
-for name in options.split("\n"):
-    if name != "" and not name in excluded:
+for line in options.split("\n"):
+    m = re.match(r"\s+(?:-[^-]+)?--(\S+)\s", line)
+    if m:
+      name = m.group(1)
+      if name != "" and not name in excluded:
         camelCase = toCamelCase(name)
         if camelCase in defaultValues:
-            txt = "  %s: %s" % (camelCase, defaultValues[camelCase])
+          txt = "  %s: %s" % (camelCase, defaultValues[camelCase])
         else:
-            txt = "# %s:" % camelCase
+          txt = "# %s:" % camelCase
         print(txt)

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -79,6 +79,8 @@ type DNSControllerSettings struct {
 	// AdditionalWait is the additional wait time after DNS propagation
 	// to wait for "last mile" propagation to DNS server used by the ACME server
 	AdditionalWait time.Duration
+	// PropagationTimeout is the propagation timeout for the DNS challenge.
+	PropagationTimeout time.Duration
 }
 
 // ObtainOutput is the result of the certificate obtain request.

--- a/pkg/cert/legobridge/dnscontrollerprovider.go
+++ b/pkg/cert/legobridge/dnscontrollerprovider.go
@@ -56,7 +56,7 @@ func newDNSControllerProvider(cluster resources.Cluster, settings DNSControllerS
 		certificateName: certificateName,
 		targetClass:     targetClass,
 		issuerName:      issuerName,
-		ttl:             int64(0.501 * dns01.DefaultPropagationTimeout.Seconds()),
+		ttl:             int64(settings.PropagationTimeout.Seconds()),
 		initialWait:     true,
 		presenting:      map[string][]string{}}, nil
 }
@@ -233,7 +233,7 @@ func (p *dnsControllerProvider) checkDNSEntryNotPending(domain string, values []
 }
 
 func (p *dnsControllerProvider) Timeout() (timeout, interval time.Duration) {
-	waitTimeout := dns01.DefaultPropagationTimeout
+	waitTimeout := p.settings.PropagationTimeout
 	if p.initialWait {
 		p.initialWait = false
 		// The Timeout function is called several times after all domains are "presented".

--- a/pkg/controller/issuer/controller.go
+++ b/pkg/controller/issuer/controller.go
@@ -45,6 +45,7 @@ func init() {
 		DefaultedStringOption(core.OptPrecheckNameservers, "8.8.8.8:53,8.8.4.4:53",
 			"DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf").
 		DefaultedDurationOption(core.OptPrecheckAdditionalWait, 10*time.Second, "additional wait time after DNS propagation check").
+		DefaultedDurationOption(core.OptPropagationTimeout, 60*time.Second, "propagation timeout for DNS challenge").
 		DefaultedIntOption(core.OptDefaultRequestsPerDayQuota, 10000,
 			"Default value for requestsPerDayQuota if not set explicitly in the issuer spec.").
 		FinalizerDomain(cert.GroupName).

--- a/pkg/controller/issuer/core/const.go
+++ b/pkg/controller/issuer/core/const.go
@@ -39,4 +39,6 @@ const (
 	OptPrecheckAdditionalWait = "precheck-additional-wait"
 	// OptDefaultRequestsPerDayQuota allows to set a default value for requestsPerDayQuota if not set explicitly in the issuer spec.
 	OptDefaultRequestsPerDayQuota = "default-requests-per-day-quota"
+	// OptPropagationTimeout is the propagation timeout for the DNS01 challenge.
+	OptPropagationTimeout = "propagation-timeout"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
On Alicloud DNS the DNS record with the DNS challenge is not propagated with the current fixed TTL setting of 30s.
With TTL of 60s it is propagated correctly to public DNS servers.
With this PR, the TTL is set to the propagation timeout of the DNS challenge.
This propagation timeout defaults to 60s.
Additionally it can set with the command line option `--propagation-timeout`.

**Which issue(s) this PR fixes**:
Fixes #32 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix propagation of DNS entry on Alicloud DNS by setting default TTL to 60s
```
```improvement operator
New command line option `--propagation-timeout`
```
