### PR TITLE
updated controller-manager-library for startup check issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.1.1-0.20200505095016-1674d986dfac
+	github.com/gardener/controller-manager-library v0.1.1-0.20200709142337-f9a87426b56d
 	github.com/gardener/external-dns-management v0.7.10
 	github.com/go-acme/lego/v3 v3.7.0
 	github.com/go-openapi/spec v0.19.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gardener/controller-manager-library v0.1.1-0.20200402075246-46a23d87218c/go.mod h1:v6cbldxmpL2fYBEB2lSnq3LSEPwIHus9En6iIhwNE1k=
-github.com/gardener/controller-manager-library v0.1.1-0.20200505095016-1674d986dfac h1:T/dSauT3b6ma24Np9CW2W8bZiY08H0E1DFWXwrYkpek=
-github.com/gardener/controller-manager-library v0.1.1-0.20200505095016-1674d986dfac/go.mod h1:v6cbldxmpL2fYBEB2lSnq3LSEPwIHus9En6iIhwNE1k=
+github.com/gardener/controller-manager-library v0.1.1-0.20200709142337-f9a87426b56d h1:2LOUgXsrod6J1JDkwk+s3g8t7SFywvPkQpBL9ugjUjw=
+github.com/gardener/controller-manager-library v0.1.1-0.20200709142337-f9a87426b56d/go.mod h1:v6cbldxmpL2fYBEB2lSnq3LSEPwIHus9En6iIhwNE1k=
 github.com/gardener/external-dns-management v0.7.10 h1:d4kBs/nv+FWXEFwp1J+ncMFwNTUggeqtBm26Z5aqxuY=
 github.com/gardener/external-dns-management v0.7.10/go.mod h1:eLmZ0jnuGywTK3pHUGCiobzCpYdvwmDwjI5Mi48htvY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/controller.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/controller.go
@@ -483,7 +483,7 @@ func (this *controller) Check() error {
 
 	// setup and check cluster handlers for all required cluster
 	for cname, watches := range this.GetDefinition().Watches() {
-		_, err := this.GetClusterHandler(cname)
+		h, err := this.GetClusterHandler(cname)
 		if err != nil {
 			return err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.5.0+incompatible
 github.com/evanphx/json-patch
-# github.com/gardener/controller-manager-library v0.1.1-0.20200505095016-1674d986dfac
+# github.com/gardener/controller-manager-library v0.1.1-0.20200709142337-f9a87426b56d
 github.com/gardener/controller-manager-library/pkg/controllermanager
 github.com/gardener/controller-manager-library/pkg/controllermanager/cluster
 github.com/gardener/controller-manager-library/pkg/controllermanager/config


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue in the controller-manager-library on controller startup with checks of watcher on wrong cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
bug fix for watches check on controller startup in the controller-manager-library
```
