### PR TITLE
Update channel name for posting release notes

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,7 +22,7 @@ cert-management:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:
             internal_scp_workspace:
-              channel_name: 'GRF0JR6G3' #k8s-developer-on-duty
+              channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
     patch-release:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Release notes will be posted to #sap-tech-gardener channel.

As far as I could tell this was the only component that posted release notes to the #k8s-developer-on-duty channel, which was in the meantime moved to a different workspace and hence the channel id changed.
The new channel id and name of the former #k8s-developer-on-duty channel is
`G0172CDN3AS` # gardener-developer-on-duty

If you think the release notes should not be posted to #sap-tech-gardener but instead to #gardener-developer-on-duty I can update the PR accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
