### PR TITLE
leader election only on default cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3
+	github.com/gardener/controller-manager-library v0.2.1-0.20200826084112-e3fae4e04030
 	github.com/gardener/external-dns-management v0.7.17-0.20200810112859-d9ceb5e2257d
 	github.com/go-acme/lego/v3 v3.7.0
 	github.com/go-openapi/spec v0.19.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gardener/controller-manager-library v0.2.1-0.20200810091329-d980dbe10959 h1:uu2LUpjtkOdMtaYwXwU8mP4yKQvUnYxsVyHtJdQM+J8=
 github.com/gardener/controller-manager-library v0.2.1-0.20200810091329-d980dbe10959/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3 h1:/FR89opaR3lbLX0is9f3ioc+i4k3cMpYxOKEwi6UzMg=
-github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
+github.com/gardener/controller-manager-library v0.2.1-0.20200826084112-e3fae4e04030 h1:QbqIx38gMrzYHC1LweqLEP99xgQm8Bb/dRclrrZI7n0=
+github.com/gardener/controller-manager-library v0.2.1-0.20200826084112-e3fae4e04030/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
 github.com/gardener/external-dns-management v0.7.17-0.20200810112859-d9ceb5e2257d h1:oA5pjPJd/wL73A3DZZLxnanNm45bpBPG/WrSQuwyX/I=
 github.com/gardener/external-dns-management v0.7.17-0.20200810112859-d9ceb5e2257d/go.mod h1:oHhauLQ3/sop0c1urS6n304Wqv/WM4me0geLn9nTAcY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/controller/issuer/controller.go
+++ b/pkg/controller/issuer/controller.go
@@ -32,7 +32,6 @@ import (
 
 func init() {
 	controller.Configure("issuer").
-		RequireLease().
 		DefaultedStringOption(core.OptDefaultIssuer, "default-issuer", "name of default issuer (from default cluster)").
 		DefaultedStringOption(core.OptIssuerNamespace, "default", "namespace to lookup issuers on default cluster").
 		StringOption(core.OptDefaultIssuerDomainRanges, "domain range restrictions when using default issuer separated by comma").
@@ -61,6 +60,7 @@ func init() {
 		WorkerPool("secrets", 1, 0).
 		SelectedWatch(selectIssuerNamespaceSelectionFunction, "core", "Secret").
 		Cluster(ctrl.DNSCluster).
+		RequireLease(ctrl.DefaultCluster).
 		MustRegister(ctrl.ControllerGroupCert)
 }
 

--- a/pkg/controller/source/ingress/controller.go
+++ b/pkg/controller/source/ingress/controller.go
@@ -27,7 +27,8 @@ var mainResource = resources.NewGroupKind("extensions", "Ingress")
 
 func init() {
 	source.CertSourceController(source.NewCertSourceTypeForCreator("ingress-cert", mainResource, NewIngressSource), nil).
-		RequireLease().
 		FinalizerDomain("cert.gardener.cloud").
+		Cluster(ctrl.DefaultCluster).
+		RequireLease(ctrl.DefaultCluster).
 		MustRegister(ctrl.ControllerGroupSource)
 }

--- a/pkg/controller/source/service/controller.go
+++ b/pkg/controller/source/service/controller.go
@@ -27,7 +27,8 @@ var mainResource = resources.NewGroupKind("core", "Service")
 
 func init() {
 	source.CertSourceController(source.NewCertSourceTypeForExtractor("service-cert", mainResource, GetSecretName), nil).
-		RequireLease().
 		FinalizerDomain("cert.gardener.cloud").
+		Cluster(ctrl.DefaultCluster).
+		RequireLease(ctrl.DefaultCluster).
 		MustRegister(ctrl.ControllerGroupSource)
 }

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/extension.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/extension.go
@@ -249,7 +249,8 @@ func (this *Extension) Start(ctx context.Context) error {
 	for _, cntr := range this.controllers {
 		def := this.registrations[cntr.GetName()]
 		if def.RequireLease() {
-			this.getLeaseStartupGroup(cntr.GetMainCluster()).Add(cntr)
+			cluster := cntr.GetCluster(def.LeaseClusterName())
+			this.getLeaseStartupGroup(cluster).Add(cntr)
 		} else {
 			this.getPlainStartupGroup(cntr.GetMainCluster()).Add(cntr)
 		}

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
@@ -166,6 +166,7 @@ type Definition interface {
 	RequiredControllers() []string
 	CustomResourceDefinitions() map[string][]*apiextensions.CustomResourceDefinitionVersions
 	RequireLease() bool
+	LeaseClusterName() string
 	FinalizerName() string
 	ActivateExplicitly() bool
 	ConfigOptions() map[string]OptionDefinition

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/syncer.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/syncer.go
@@ -194,16 +194,16 @@ func (this *SyncRequest) update(log logger.LogContext, initiator resources.Objec
 
 	if this.resourceVersion == initiator.GetResourceVersion() {
 		if len(this.syncPoints) == 0 {
-			log.Info("synchronization %s(%s) for %s(%s) done", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
+			log.Infof("synchronization %s(%s) for %s(%s) done", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
 			return true, nil
 		}
-		log.Info("synchronization %s(%s) for %s(%s) still pending", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
+		log.Infof("synchronization %s(%s) for %s(%s) still pending", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
 		return false, nil
 	}
 	if this.resourceVersion == "" {
-		log.Info("synchronizing %s(%s) for %s(%s)", this.name, this.resource, initiator, initiator.GetResourceVersion())
+		log.Infof("synchronizing %s(%s) for %s(%s)", this.name, this.resource, initiator, initiator.GetResourceVersion())
 	} else {
-		log.Info("resynchronizing %s(%s) for %s(%s->%s)", this.name, this.resource, initiator, this.resourceVersion, initiator.GetResourceVersion())
+		log.Infof("resynchronizing %s(%s) for %s(%s->%s)", this.name, this.resource, initiator, this.resourceVersion, initiator.GetResourceVersion())
 	}
 	this.resourceVersion = initiator.GetResourceVersion()
 	reconcilers := this.controller.mappings.Get(this.cluster, this.resource.GroupKind())
@@ -216,7 +216,7 @@ func (this *SyncRequest) update(log logger.LogContext, initiator resources.Objec
 	}
 	this.syncPoints = SyncPoints{}
 	if len(list) == 0 {
-		log.Info("  no %s found for sync -> done", this.resource)
+		log.Infof("  no %s found for sync -> done", this.resource)
 		return true, nil
 	}
 	if len(reconcilers) == 1 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/evanphx/json-patch
 github.com/evanphx/json-patch/v5
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3
+# github.com/gardener/controller-manager-library v0.2.1-0.20200826084112-e3fae4e04030
 github.com/gardener/controller-manager-library/pkg/certmgmt
 github.com/gardener/controller-manager-library/pkg/certs
 github.com/gardener/controller-manager-library/pkg/config


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the leader election is moved to the default cluster (the seed cluster in Gardener context).
Formerly it was on the source cluster (the shoot cluster), which causes restarts if the network is temporarily not working and the leader election cannot performed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
move leader election to default cluster, i.e. the control plane
```
