### PR TITLE
role to access cluster-identity

### DIFF
--- a/charts/cert-management/templates/role-kube-system.yaml
+++ b/charts/cert-management/templates/role-kube-system.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cert-management.fullname" . }}
+  namespace: kube-system
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cluster-identity
+  verbs:
+  - get

--- a/charts/cert-management/templates/rolebinding-kube-system.yaml
+++ b/charts/cert-management/templates/rolebinding-kube-system.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-management.fullname" . }}
+  namespace: kube-system
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cert-management.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cert-management.fullname" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
add role to access `cluster-identity` configmap in `kube-system` namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
fix helm chart: add role to access configmap `cluster-identity` in `kube-system` namespace.
```
