### PR TITLE
cleanup orphan outdated certificate secrets

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder       #############
-FROM golang:1.13.9 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.3 AS builder
 
 WORKDIR /build
 COPY . .
@@ -11,7 +11,7 @@ COPY . .
 RUN make release
 
 ############# base
-FROM alpine:3.11.3 AS base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 AS base
 
 #############      cert-controller-manager     #############
 FROM base AS cert-controller-manager

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -327,12 +327,9 @@ func DecodeCertificateFromSecretData(data map[string][]byte) (*x509.Certificate,
 
 // DecodeCertificate decodes the crt byte array.
 func DecodeCertificate(tlsCrt []byte) (*x509.Certificate, error) {
-	block, rest := pem.Decode(tlsCrt)
+	block, _ := pem.Decode(tlsCrt)
 	if block == nil {
 		return nil, fmt.Errorf("decoding pem for %s from request secret failed", corev1.TLSCertKey)
-	}
-	if len(rest) > 0 {
-		return nil, fmt.Errorf("incomplete decoding pem block for public key certificate")
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The secret referenced by a certificate custom resource is not deleted if the certificate CR is deleted, 
because it is unclear if the certificate will be recreated, e.g if the source object has been disappeared temporarily.
With this PR a garbage collection is added which deletes a certificate secret if it is not referenced by a certificate CR and it is outdated at least for 14 days. The garbage collection runs on startup and every 7 days.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
cleanup orphan outdated certificate secrets
```
