### PR TITLE
common name annotation for services and ingresses

### DIFF
--- a/examples/40-ingress-echoheaders.yaml
+++ b/examples/40-ingress-echoheaders.yaml
@@ -9,6 +9,9 @@ metadata:
   namespace: default
   annotations:
     cert.gardener.cloud/purpose: managed
+    #dns.gardener.cloud/class: garden # needed on Gardener shoot clusters for managed DNS record creation
+    #cert.gardener.cloud/commonname: "*.demo.mydomain.com" # optional, if not specified the first name from spec.tls[].hosts is used as common name
+    #cert.gardener.cloud/dnsnames: "" # optional, if not specified the names from spec.tls[].hosts are used
 spec:
   tls:
     - hosts:

--- a/examples/40-service-loadbalancer.yaml
+++ b/examples/40-service-loadbalancer.yaml
@@ -9,6 +9,9 @@ metadata:
     cert.gardener.cloud/secretname: test-service-secret
     dns.gardener.cloud/dnsnames: test-service.demo.mydomain.com
     dns.gardener.cloud/ttl: "600"
+    #dns.gardener.cloud/class: garden # needed on Gardener shoot clusters for managed DNS record creation
+    #cert.gardener.cloud/commonname: "*.demo.mydomain.com" # optional, if not specified the first name from dns.gardener.cloud/dnsnames is used as common name
+    #cert.gardener.cloud/dnsnames: "" # optional, if specified overrides dns.gardener.cloud/dnsnames annotation for certificate names
   name: test-service
   namespace: default
 spec:

--- a/pkg/cert/source/controller.go
+++ b/pkg/cert/source/controller.go
@@ -32,6 +32,10 @@ const (
 	AnnotSecretname = "cert.gardener.cloud/secretname"
 	// AnnotIssuer is the annotation for the issuer name
 	AnnotIssuer = "cert.gardener.cloud/issuer"
+	// AnnotCommonName is the annotation for explicitly specifying the common name
+	AnnotCommonName = "cert.gardener.cloud/commonname"
+	// AnnotCertDNSNames is the annotation for explicitly specifying the DNS names (if not specified, values from "dns.gardener.cloud/dnsnames" is used)
+	AnnotCertDNSNames = "cert.gardener.cloud/dnsnames"
 
 	// OptClass is the cert-class command line option
 	OptClass = "cert-class"

--- a/pkg/cert/source/defaults.go
+++ b/pkg/cert/source/defaults.go
@@ -155,15 +155,23 @@ func (s *DefaultCertSource) NewCertsInfo(logger logger.LogContext, obj resources
 func (s *DefaultCertSource) GetCertsInfo(logger logger.LogContext, obj resources.Object, current *CertCurrentState) (*CertsInfo, error) {
 	info := s.NewCertsInfo(logger, obj)
 	secretName, err := s.handler(logger, obj, current)
-	a, ok := resources.GetAnnotation(obj.Data(), AnnotDnsnames)
+	a, ok := resources.GetAnnotation(obj.Data(), AnnotCertDNSNames)
 	if err != nil || !ok {
-		return nil, nil
+		a, ok = resources.GetAnnotation(obj.Data(), AnnotDnsnames)
+		if err != nil || !ok {
+			return nil, nil
+		}
 	}
 
+	cn, _ := resources.GetAnnotation(obj.Data(), AnnotCommonName)
+	cn = strings.TrimSpace(cn)
 	annotatedDomains := []string{}
+	if cn != "" {
+		annotatedDomains = append(annotatedDomains, cn)
+	}
 	for _, e := range strings.Split(a, ",") {
 		e = strings.TrimSpace(e)
-		if e != "" {
+		if e != "" && e != cn {
 			annotatedDomains = append(annotatedDomains, e)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to specify the common name for certificates of services and ingresses explicitly by using an annotation `cert.gardener.cloud/commonname`.

**Which issue(s) this PR fixes**:
Fixes #48 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
optional common name annotation for services and ingresses
```
