### PR TITLE
renew certificate if its certificate secret is invalid/corrupt instead of going to state error

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -624,10 +624,11 @@ func (r *certReconciler) checkForRenewAndSucceeded(logger logger.LogContext, obj
 
 	cert, err := legobridge.DecodeCertificateFromSecretData(secret.Data)
 	if err != nil {
-		return r.failed(logger, obj, api.StateError, err)
+		logger.Errorf("certificate secret cannot be decoded: %s", err)
+	} else {
+		logger.Infof("certificate valid from %v to %v", cert.NotBefore, cert.NotAfter)
 	}
-	logger.Infof("certificate valid from %v to %v", cert.NotBefore, cert.NotAfter)
-	if r.needsRenewal(cert) {
+	if cert == nil || r.needsRenewal(cert) {
 		if crt.Status.State == api.StatePending && r.lastPendingRateLimiting(crt.Status.LastPendingTimestamp) {
 			return reconcile.Succeeded(logger)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a fix for a corner case. If a certificate was successfully requested and later the secret data is deleted or corrupt,
the certificate object went to state error, as the validity of the secret could not be checked.
E.g. status of the certificate shows:
```
status:
  message: fetching tls.crt from request secret failed
  state: Error
```
With this change, the invalid secret data is ignored and processed as if it needs to be renewed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
renew certificate if its certificate secret is invalid/corrupt instead of going to state error
```
