### PR TITLE
Add metrics for expiring certificates and use common prefix for metric names

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Flags:
       --dns-owner-id string                                ownerId for creating challenge DNSEntries
       --dns.disable-deploy-crds                            disable deployment of required crds for cluster dns
       --dns.id string                                      id for cluster dns
+      --dns.migration-ids string                           migration id for cluster dns
       --force-crd-update                                   enforce update of crds even they are unmanaged
       --grace-period duration                              inactivity grace period for detecting end of cleanup for shutdown
   -h, --help                                               help for cert-controller-manager
@@ -541,12 +542,14 @@ Flags:
       --issuer.precheck-additional-wait duration           additional wait time after DNS propagation check of controller issuer (default 10s)
       --issuer.precheck-nameservers string                 DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf of controller issuer (default "8.8.8.8:53,8.8.4.4:53")
       --issuer.propagation-timeout duration                propagation timeout for DNS challenge of controller issuer (default 1m0s)
+      --issuer.renewal-overdue-window duration             certificate is counted as 'renewal overdue' if its validity period is shorter (metrics cert_management_overdue_renewal_certificates) of controller issuer (default 600h0m0s)
       --issuer.renewal-window duration                     certificate is renewed if its validity period is shorter of controller issuer (default 720h0m0s)
       --issuer.secrets.pool.size int                       Worker pool size for pool secrets of controller issuer (default 1)
       --issuers.pool.size int                              Worker pool size for pool issuers
       --kubeconfig string                                  default cluster access
       --kubeconfig.disable-deploy-crds                     disable deployment of required crds for cluster default
       --kubeconfig.id string                               id for cluster default
+      --kubeconfig.migration-ids string                    migration id for cluster default
       --lease-duration duration                            lease duration (default 15s)
       --lease-name string                                  name for lease object
       --lease-renew-deadline duration                      lease renew deadline (default 10s)
@@ -563,6 +566,7 @@ Flags:
       --precheck-additional-wait duration                  additional wait time after DNS propagation check
       --precheck-nameservers string                        DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf
       --propagation-timeout duration                       propagation timeout for DNS challenge
+      --renewal-overdue-window duration                    certificate is counted as 'renewal overdue' if its validity period is shorter (metrics cert_management_overdue_renewal_certificates)
       --renewal-window duration                            certificate is renewed if its validity period is shorter
       --secrets.pool.size int                              Worker pool size for pool secrets
       --server-port-http int                               HTTP server port (serving /healthz, /metrics, ...)
@@ -578,11 +582,13 @@ Flags:
       --source string                                      source cluster to watch for ingresses and services
       --source.disable-deploy-crds                         disable deployment of required crds for cluster source
       --source.id string                                   id for cluster source
+      --source.migration-ids string                        migration id for cluster source
       --target string                                      target cluster for certificates
       --target-name-prefix string                          name prefix in target namespace for cross cluster generation
       --target-namespace string                            target namespace for cross cluster generation
       --target.disable-deploy-crds                         disable deployment of required crds for cluster target
       --target.id string                                   id for cluster target
+      --target.migration-ids string                        migration id for cluster target
       --targets.pool.size int                              Worker pool size for pool targets
   -v, --version                                            version for cert-controller-manager
 ```

--- a/charts/cert-management/templates/deployment.yaml
+++ b/charts/cert-management/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         args:
         - --name={{ include "cert-management.fullname" . }}
         ### start generated configuration
+        {{- if .Values.configuration.acceptedMaintainers }}
+        - --accepted-maintainers={{ .Values.configuration.acceptedMaintainers }}
+        {{- end }}
         {{- if .Values.configuration.bindAddressHttp }}
         - --bind-address-http={{ .Values.configuration.bindAddressHttp }}
         {{- end }}
@@ -90,6 +93,12 @@ spec:
         {{- end }}
         {{- if .Values.configuration.dnsId }}
         - --dns.id={{ .Values.configuration.dnsId }}
+        {{- end }}
+        {{- if .Values.configuration.dnsMigrationIds }}
+        - --dns.migration-ids={{ .Values.configuration.dnsMigrationIds }}
+        {{- end }}
+        {{- if .Values.configuration.forceCrdUpdate }}
+        - --force-crd-update={{ .Values.configuration.forceCrdUpdate }}
         {{- end }}
         {{- if .Values.configuration.gracePeriod }}
         - --grace-period={{ .Values.configuration.gracePeriod }}
@@ -175,6 +184,9 @@ spec:
         {{- if .Values.configuration.issuerPropagationTimeout }}
         - --issuer.propagation-timeout={{ .Values.configuration.issuerPropagationTimeout }}
         {{- end }}
+        {{- if .Values.configuration.issuerRenewalOverdueWindow }}
+        - --issuer.renewal-overdue-window={{ .Values.configuration.issuerRenewalOverdueWindow }}
+        {{- end }}
         {{- if .Values.configuration.issuerRenewalWindow }}
         - --issuer.renewal-window={{ .Values.configuration.issuerRenewalWindow }}
         {{- end }}
@@ -192,6 +204,9 @@ spec:
         {{- end }}
         {{- if .Values.configuration.kubeconfigId }}
         - --kubeconfig.id={{ .Values.configuration.kubeconfigId }}
+        {{- end }}
+        {{- if .Values.configuration.kubeconfigMigrationIds }}
+        - --kubeconfig.migration-ids={{ .Values.configuration.kubeconfigMigrationIds }}
         {{- end }}
         {{- if .Values.configuration.leaseDuration }}
         - --lease-duration={{ .Values.configuration.leaseDuration }}
@@ -238,6 +253,9 @@ spec:
         {{- if .Values.configuration.propagationTimeout }}
         - --propagation-timeout={{ .Values.configuration.propagationTimeout }}
         {{- end }}
+        {{- if .Values.configuration.renewalOverdueWindow }}
+        - --renewal-overdue-window={{ .Values.configuration.renewalOverdueWindow }}
+        {{- end }}
         {{- if .Values.configuration.renewalWindow }}
         - --renewal-window={{ .Values.configuration.renewalWindow }}
         {{- end }}
@@ -283,6 +301,9 @@ spec:
         {{- if .Values.configuration.sourceId }}
         - --source.id={{ .Values.configuration.sourceId }}
         {{- end }}
+        {{- if .Values.configuration.sourceMigrationIds }}
+        - --source.migration-ids={{ .Values.configuration.sourceMigrationIds }}
+        {{- end }}
         {{- if .Values.configuration.target }}
         - --target={{ .Values.configuration.target }}
         {{- end }}
@@ -297,6 +318,9 @@ spec:
         {{- end }}
         {{- if .Values.configuration.targetId }}
         - --target.id={{ .Values.configuration.targetId }}
+        {{- end }}
+        {{- if .Values.configuration.targetMigrationIds }}
+        - --target.migration-ids={{ .Values.configuration.targetMigrationIds }}
         {{- end }}
         {{- if .Values.configuration.targetsPoolSize }}
         - --targets.pool.size={{ .Values.configuration.targetsPoolSize }}

--- a/charts/cert-management/values.yaml
+++ b/charts/cert-management/values.yaml
@@ -30,6 +30,7 @@ createCRDs:
   certificates: true
 
 configuration:
+  # acceptedMaintainers:
   # bindAddressHttp:
   # cascadeDelete:
   # certClass:
@@ -49,6 +50,8 @@ configuration:
   # dnsOwnerId:
   # dnsDisableDeployCrds:
   # dnsId:
+  # dnsMigrationIds:
+  # forceCrdUpdate:
   # gracePeriod:
   # ingressCertCertClass:
   # ingressCertCertTargetClass:
@@ -77,12 +80,14 @@ configuration:
   # issuerPrecheckAdditionalWait:
   # issuerPrecheckNameservers:
   # issuerPropagationTimeout:
+  # issuerRenewalOverdueWindow:
   # issuerRenewalWindow:
   # issuerSecretsPoolSize:
   # issuersPoolSize:
   # kubeconfig:
   # kubeconfigDisableDeployCrds:
   # kubeconfigId:
+  # kubeconfigMigrationIds:
   # leaseDuration:
   # leaseName:
   # leaseRenewDeadline:
@@ -98,6 +103,7 @@ configuration:
   # precheckAdditionalWait:
   # precheckNameservers:
   # propagationTimeout:
+  # renewalOverdueWindow:
   # renewalWindow:
   # secretsPoolSize:
   serverPortHttp: 8080
@@ -113,11 +119,13 @@ configuration:
   # source:
   # sourceDisableDeployCrds:
   # sourceId:
+  # sourceMigrationIds:
   # target:
   # targetNamePrefix:
   # targetNamespace:
   # targetDisableDeployCrds:
   # targetId:
+  # targetMigrationIds:
   # targetsPoolSize:
   # version:
 

--- a/hack/generateChartOptions.py
+++ b/hack/generateChartOptions.py
@@ -8,101 +8,15 @@
 
 
 import re
+import os
 
-options = """
-      --bind-address-http string                           HTTP server bind address
-      --cascade-delete                                     If true, certificate secrets are deleted if dependent resources (certificate, ingress) are deleted
-      --cert-class string                                  Identifier used to differentiate responsible controllers for entries
-      --cert-target-class string                           Identifier used to differentiate responsible dns controllers for target entries
-      --config string                                      config file
-  -c, --controllers string                                 comma separated list of controllers to start (<name>,<group>,all) (default "all")
-      --cpuprofile string                                  set file for cpu profiling
-      --default-issuer string                              name of default issuer (from default cluster)
-      --default-issuer-domain-ranges string                domain range restrictions when using default issuer separated by comma
-      --default-requests-per-day-quota int                 Default value for requestsPerDayQuota if not set explicitly in the issuer spec.
-      --default.pool.resync-period duration                Period for resynchronization for pool default
-      --default.pool.size int                              Worker pool size for pool default
-      --disable-namespace-restriction                      disable access restriction for namespace local access only
-      --dns string                                         cluster for writing challenge DNS entries
-      --dns-class string                                   class for creating challenge DNSEntries (in DNS cluster)
-      --dns-namespace string                               namespace for creating challenge DNSEntries (in DNS cluster)
-      --dns-owner-id string                                ownerId for creating challenge DNSEntries
-      --dns.disable-deploy-crds                            disable deployment of required crds for cluster dns
-      --dns.id string                                      id for cluster dns
-      --grace-period duration                              inactivity grace period for detecting end of cleanup for shutdown
-  -h, --help                                               help for cert-controller-manager
-      --ingress-cert.cert-class string                     Identifier used to differentiate responsible controllers for entries of controller ingress-cert (default "gardencert")
-      --ingress-cert.cert-target-class string              Identifier used to differentiate responsible dns controllers for target entries of controller ingress-cert
-      --ingress-cert.default.pool.resync-period duration   Period for resynchronization for pool default of controller ingress-cert (default 2m0s)
-      --ingress-cert.default.pool.size int                 Worker pool size for pool default of controller ingress-cert (default 2)
-      --ingress-cert.pool.resync-period duration           Period for resynchronization of controller ingress-cert
-      --ingress-cert.pool.size int                         Worker pool size of controller ingress-cert
-      --ingress-cert.target-name-prefix string             name prefix in target namespace for cross cluster generation of controller ingress-cert
-      --ingress-cert.target-namespace string               target namespace for cross cluster generation of controller ingress-cert
-      --ingress-cert.targets.pool.size int                 Worker pool size for pool targets of controller ingress-cert (default 2)
-      --issuer-namespace string                            namespace to lookup issuers on default cluster
-      --issuer.cascade-delete                              If true, certificate secrets are deleted if dependent resources (certificate, ingress) are deleted of controller issuer
-      --issuer.cert-class string                           Identifier used to differentiate responsible controllers for entries of controller issuer
-      --issuer.default-issuer string                       name of default issuer (from default cluster) of controller issuer (default "default-issuer")
-      --issuer.default-issuer-domain-ranges string         domain range restrictions when using default issuer separated by comma of controller issuer
-      --issuer.default-requests-per-day-quota int          Default value for requestsPerDayQuota if not set explicitly in the issuer spec. of controller issuer (default 10000)
-      --issuer.default.pool.resync-period duration         Period for resynchronization for pool default of controller issuer (default 24h0m0s)
-      --issuer.default.pool.size int                       Worker pool size for pool default of controller issuer (default 2)
-      --issuer.dns-class string                            class for creating challenge DNSEntries (in DNS cluster) of controller issuer
-      --issuer.dns-namespace string                        namespace for creating challenge DNSEntries (in DNS cluster) of controller issuer
-      --issuer.dns-owner-id string                         ownerId for creating challenge DNSEntries of controller issuer
-      --issuer.issuer-namespace string                     namespace to lookup issuers on default cluster of controller issuer (default "default")
-      --issuer.issuers.pool.size int                       Worker pool size for pool issuers of controller issuer (default 1)
-      --issuer.pool.resync-period duration                 Period for resynchronization of controller issuer
-      --issuer.pool.size int                               Worker pool size of controller issuer
-      --issuer.precheck-additional-wait duration           additional wait time after DNS propagation check of controller issuer (default 10s)
-      --issuer.precheck-nameservers string                 DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf of controller issuer (default "8.8.8.8:53,8.8.4.4:53")
-      --issuer.propagation-timeout duration                propagation timeout for DNS challenge of controller issuer (default 1m0s)
-      --issuer.renewal-window duration                     certificate is renewed if its validity period is shorter of controller issuer (default 720h0m0s)
-      --issuer.secrets.pool.size int                       Worker pool size for pool secrets of controller issuer (default 1)
-      --issuers.pool.size int                              Worker pool size for pool issuers
-      --kubeconfig string                                  default cluster access
-      --kubeconfig.disable-deploy-crds                     disable deployment of required crds for cluster default
-      --kubeconfig.id string                               id for cluster default
-      --lease-duration duration                            lease duration (default 15s)
-      --lease-name string                                  name for lease object
-      --lease-renew-deadline duration                      lease renew deadline (default 10s)
-      --lease-retry-period duration                        lease retry period (default 2s)
-  -D, --log-level string                                   logrus log level
-      --maintainer string                                  maintainer key for crds (defaulted by manager name)
-      --name string                                        name used for controller manager
-      --namespace string                                   namespace for lease (default "kube-system")
-  -n, --namespace-local-access-only                        enable access restriction for namespace local access only (deprecated)
-      --omit-lease                                         omit lease for development
-      --plugin-file string                                 directory containing go plugins
-      --pool.resync-period duration                        Period for resynchronization
-      --pool.size int                                      Worker pool size
-      --precheck-additional-wait duration                  additional wait time after DNS propagation check
-      --precheck-nameservers string                        DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf
-      --propagation-timeout duration                       propagation timeout for DNS challenge
-      --renewal-window duration                            certificate is renewed if its validity period is shorter
-      --secrets.pool.size int                              Worker pool size for pool secrets
-      --server-port-http int                               HTTP server port (serving /healthz, /metrics, ...)
-      --service-cert.cert-class string                     Identifier used to differentiate responsible controllers for entries of controller service-cert (default "gardencert")
-      --service-cert.cert-target-class string              Identifier used to differentiate responsible dns controllers for target entries of controller service-cert
-      --service-cert.default.pool.resync-period duration   Period for resynchronization for pool default of controller service-cert (default 2m0s)
-      --service-cert.default.pool.size int                 Worker pool size for pool default of controller service-cert (default 2)
-      --service-cert.pool.resync-period duration           Period for resynchronization of controller service-cert
-      --service-cert.pool.size int                         Worker pool size of controller service-cert
-      --service-cert.target-name-prefix string             name prefix in target namespace for cross cluster generation of controller service-cert
-      --service-cert.target-namespace string               target namespace for cross cluster generation of controller service-cert
-      --service-cert.targets.pool.size int                 Worker pool size for pool targets of controller service-cert (default 2)
-      --source string                                      source cluster to watch for ingresses and services
-      --source.disable-deploy-crds                         disable deployment of required crds for cluster source
-      --source.id string                                   id for cluster source
-      --target string                                      target cluster for certificates
-      --target-name-prefix string                          name prefix in target namespace for cross cluster generation
-      --target-namespace string                            target namespace for cross cluster generation
-      --target.disable-deploy-crds                         disable deployment of required crds for cluster target
-      --target.id string                                   id for cluster target
-      --targets.pool.size int                              Worker pool size for pool targets
-  -v, --version                                            version for cert-controller-manager
-"""
+helpFilename = "/tmp/cert-controller-manager-help.txt"
+rc = os.system("make build-local && ./cert-controller-manager --help | grep ' --' > {}".format(helpFilename))
+if rc != 0:
+  exit(rc)
+f = open(helpFilename,"r")
+options = f.read()
+os.remove(helpFilename)
 
 def toCamelCase(name):
   str = ''.join(x.capitalize() for x in re.split("[.-]", name))

--- a/pkg/cert/metrics/metrics.go
+++ b/pkg/cert/metrics/metrics.go
@@ -26,7 +26,7 @@ var (
 	// ACMEAccountRegistrations is the acme_account_registrations counter.
 	ACMEAccountRegistrations = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "acme_account_registrations",
+			Name: "cert_management_acme_account_registrations",
 			Help: "Number of ACME account registrations",
 		},
 		[]string{"server", "email"},
@@ -35,7 +35,7 @@ var (
 	// ACMETotalObtains is the acme_obtains counter.
 	ACMETotalObtains = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "acme_obtains",
+			Name: "cert_management_acme_obtains",
 			Help: "Total number of ACME obtains",
 		},
 		[]string{"issuer", "success", "dns_challenges", "renew"},
@@ -44,7 +44,7 @@ var (
 	// ACMEActiveDNSChallenges is the acme_active_dns_challenges gauge.
 	ACMEActiveDNSChallenges = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "acme_active_dns_challenges",
+			Name: "cert_management_acme_active_dns_challenges",
 			Help: "Currently active number of ACME DNS challenges",
 		},
 		[]string{"issuer"},
@@ -53,8 +53,8 @@ var (
 	// CertEntries is the cert_entries gauge.
 	CertEntries = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "cert_entries",
-			Help: "Total number of cert entries per issuer",
+			Name: "cert_management_cert_entries",
+			Help: "Total number of certificate objects per issuer",
 		},
 		[]string{"issuertype", "issuer"},
 	)

--- a/pkg/cert/metrics/metrics.go
+++ b/pkg/cert/metrics/metrics.go
@@ -18,12 +18,13 @@ func init() {
 	prometheus.MustRegister(ACMETotalObtains)
 	prometheus.MustRegister(ACMEActiveDNSChallenges)
 	prometheus.MustRegister(CertEntries)
+	prometheus.MustRegister(OverdueCertificates)
 
 	server.RegisterHandler("/metrics", promhttp.Handler())
 }
 
 var (
-	// ACMEAccountRegistrations is the acme_account_registrations counter.
+	// ACMEAccountRegistrations is the cert_management_acme_account_registrations counter.
 	ACMEAccountRegistrations = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cert_management_acme_account_registrations",
@@ -32,7 +33,7 @@ var (
 		[]string{"server", "email"},
 	)
 
-	// ACMETotalObtains is the acme_obtains counter.
+	// ACMETotalObtains is the cert_management_acme_obtains counter.
 	ACMETotalObtains = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cert_management_acme_obtains",
@@ -41,7 +42,7 @@ var (
 		[]string{"issuer", "success", "dns_challenges", "renew"},
 	)
 
-	// ACMEActiveDNSChallenges is the acme_active_dns_challenges gauge.
+	// ACMEActiveDNSChallenges is the cert_management_acme_active_dns_challenges gauge.
 	ACMEActiveDNSChallenges = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cert_management_acme_active_dns_challenges",
@@ -50,13 +51,21 @@ var (
 		[]string{"issuer"},
 	)
 
-	// CertEntries is the cert_entries gauge.
+	// CertEntries is the cert_management_cert_entries gauge.
 	CertEntries = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cert_management_cert_entries",
 			Help: "Total number of certificate objects per issuer",
 		},
 		[]string{"issuertype", "issuer"},
+	)
+
+	// OverdueCertificates is the cert_management_overdue_renewal_certificates gauge.
+	OverdueCertificates = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cert_management_overdue_renewal_certificates",
+			Help: "Number of certificate objects with overdue renewal",
+		},
 	)
 )
 
@@ -90,4 +99,9 @@ func ReportCertEntries(issuertype, issuer string, count int) {
 // DeleteCertEntries deletes a CertEntries gauge entry.
 func DeleteCertEntries(issuertype, issuer string) {
 	CertEntries.DeleteLabelValues(issuertype, issuer)
+}
+
+// ReportOverdueCerts sets the OverdueCertificates gauge
+func ReportOverdueCerts(count int) {
+	OverdueCertificates.Set(float64(count))
 }

--- a/pkg/controller/issuer/controller.go
+++ b/pkg/controller/issuer/controller.go
@@ -32,6 +32,7 @@ func init() {
 		BoolOption(core.OptCascadeDelete, "If true, certificate secrets are deleted if dependent resources (certificate, ingress) are deleted").
 		StringOption(source.OptClass, "Identifier used to differentiate responsible controllers for entries").
 		DefaultedDurationOption(core.OptRenewalWindow, 30*24*time.Hour, "certificate is renewed if its validity period is shorter").
+		DefaultedDurationOption(core.OptRenewalOverdueWindow, 25*24*time.Hour, "certificate is counted as 'renewal overdue' if its validity period is shorter (metrics cert_management_overdue_renewal_certificates)").
 		DefaultedStringOption(core.OptPrecheckNameservers, "8.8.8.8:53,8.8.4.4:53",
 			"DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf").
 		DefaultedDurationOption(core.OptPrecheckAdditionalWait, 10*time.Second, "additional wait time after DNS propagation check").

--- a/pkg/controller/issuer/core/const.go
+++ b/pkg/controller/issuer/core/const.go
@@ -28,6 +28,8 @@ const (
 	OptDefaultIssuerDomainRanges = "default-issuer-domain-ranges"
 	// OptRenewalWindow is the renewal window command line option.
 	OptRenewalWindow = "renewal-window"
+	// OptRenewalOverdueWindow is the renewal overdue window command line option.
+	OptRenewalOverdueWindow = "renewal-overdue-window"
 	// OptCascadeDelete is the cascade delete command line option.
 	OptCascadeDelete = "cascade-delete"
 	// OptPrecheckNameservers is a command line option to specify the DNS nameservers to check DNS propagation of the DNS challenge.

--- a/pkg/controller/issuer/core/objectnameset.go
+++ b/pkg/controller/issuer/core/objectnameset.go
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2019 SAP SE or an SAP affiliate company and Gardener contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package core
+
+import (
+	"sync"
+
+	"github.com/gardener/controller-manager-library/pkg/resources"
+)
+
+// newObjectNameSet creates a synced ObjectNameSet
+func newObjectNameSet() *objectNameSet {
+	return &objectNameSet{
+		set: resources.ObjectNameSet{},
+	}
+}
+
+// objectNameSet is a synced ObjectNameSet.
+type objectNameSet struct {
+	lock sync.Mutex
+	set  resources.ObjectNameSet
+}
+
+// Add a name.
+func (s *objectNameSet) Add(name resources.ObjectName) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	old := len(s.set)
+	s.set.Add(name)
+	return len(s.set) != old
+}
+
+// Remove a name.
+func (s *objectNameSet) Remove(name resources.ObjectName) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	old := len(s.set)
+	s.set.Remove(name)
+	return len(s.set) != old
+}
+
+// AsArray returns copy of members as array
+func (s *objectNameSet) AsArray() []resources.ObjectName {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.set.AsArray()
+}
+
+func (s *objectNameSet) String() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.set.String()
+}
+
+func (s *objectNameSet) Size() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return len(s.set)
+}

--- a/pkg/controller/issuer/core/state.go
+++ b/pkg/controller/issuer/core/state.go
@@ -12,13 +12,15 @@ import (
 )
 
 type state struct {
-	secrets      *ReferencedSecrets
-	certificates *AssociatedObjects
-	quotas       *Quotas
+	secrets      ReferencedSecrets
+	certificates AssociatedObjects
+	quotas       Quotas
+	overdueCerts objectNameSet
 }
 
 func newState() *state {
-	return &state{secrets: NewReferencedSecrets(), certificates: NewAssociatedObjects(), quotas: NewQuotas()}
+	return &state{secrets: *NewReferencedSecrets(), certificates: *NewAssociatedObjects(), quotas: *NewQuotas(),
+		overdueCerts: *newObjectNameSet()}
 }
 
 func (s *state) RemoveIssuer(name resources.ObjectName) bool {
@@ -67,4 +69,20 @@ func (s *state) RememberIssuerSecret(issuer resources.ObjectName, secretRef *v1.
 
 func (s *state) GetIssuerSecretHash(issuerName resources.ObjectName) string {
 	return s.secrets.GetIssuerSecretHash(issuerName)
+}
+
+func (s *state) AddRenewalOverdue(certName resources.ObjectName) bool {
+	return s.overdueCerts.Add(certName)
+}
+
+func (s *state) RemoveRenewalOverdue(certName resources.ObjectName) bool {
+	return s.overdueCerts.Remove(certName)
+}
+
+func (s *state) GetAllRenewalOverdue() []resources.ObjectName {
+	return s.overdueCerts.AsArray()
+}
+
+func (s *state) GetRenewalOverdueCount() int {
+	return s.overdueCerts.Size()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
A metrics has been added for certificates whose renewal is overdue. A certificate is 'renewal overdue' if its expire date is within the configurable `--renewal-overdue-window` (default 25 days). 
Besides all specific metrics of the `cert-controller-manager` now have a common prefix for their names.

**Which issue(s) this PR fixes**:
Fixes #59 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Use common prefix `cert_management_` for metrics names.
```

```improvement operator
Add metrics `cert_management_overdue_renewal_certificates` to allow alerting for expiring certificates.
```