### PR TITLE
add metrics for certificate secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Currently, the `cert-controller-manager` supports certificate authorities via:
   - [Revoking Certificates](#revoking-certificates)
     - [Revoking certificates with renewal](#revoking-certificates-with-renewal)
     - [Checking OCSP revocation using OpenSSL](#checking-ocsp-revocation-using-openssl)
+  - [Metrics](#metrics)
   - [Development](#development)
 
 ## Setting up Issuers
@@ -756,6 +757,22 @@ Usage:
 hack/check-cert-secret.sh check-revoke mynamespace mycertname
 ```
 Here *mynamespace* and *mycertname* are the namespace and the name of the certificate object.
+
+## Metrics
+
+Metrics are exposed for Prometheus if the command line option `--server-port-http <port>` is specified.
+The endpoint URL is `http://<pod-ip>:<port>/metrics`.
+Besides the default Go metrics, the following cert-management specific metrics are provided:
+
+| Name                                         | Labels               | Description                                    |
+| -------------------------------------------- | -------------------- | ---------------------------------------------- |
+| cert_management_acme_account_registrations   | uri, email           | ACME account registrations                     |
+| cert_management_acme_orders                  | issuer, success, dns_challenges, renew | Number of ACME orders        |
+| cert_management_cert_entries                 | issuer, issuertype   | Total number of certificate objects per issuer |
+| cert_management_acme_active_dns_challenges   | issuer               | Currently active number of ACME DNS challenges |
+| cert_management_overdue_renewal_certificates | -                    | Number of certificate objects with certificate's renewal overdue |
+| cert_management_revoked_certificates         | -                    | Number of certificate objects with revoked certificate |
+| cert_management_secrets                      | classification       | Number of certificate secrets per classification (only updated on startup and every 24h on GC of secrets). Currently there are three classifications: `total` = total number of certificate secrets on the source cluster, `revoked` = number of revoked certificate secrets, `backup`= number of backups of certificate secrets (every certificate has a backup secret in the `kube-system` namespace to allow revocation even if it is not used anymore) |
 
 ## Development
 

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -209,7 +209,7 @@ func (o *obtainer) ObtainACME(input ObtainInput) error {
 			}
 		}
 		count := provider.GetChallengesCount()
-		metrics.AddACMEObtain(input.IssuerName, err == nil, count, input.RenewCert != nil)
+		metrics.AddACMEOrder(input.IssuerName, err == nil, count, input.RenewCert != nil)
 		output := &ObtainOutput{
 			Certificates: certificates,
 			IssuerInfo:   utils.NewACMEIssuerInfo(input.IssuerName),

--- a/pkg/cert/legobridge/reguser.go
+++ b/pkg/cert/legobridge/reguser.go
@@ -13,7 +13,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"net/url"
 
 	"github.com/gardener/cert-management/pkg/cert/metrics"
 
@@ -89,12 +88,7 @@ func NewRegistrationUserFromEmailAndPrivateKey(email string, caDirURL string, pr
 	}
 	user.Registration = reg
 
-	server := "unknown"
-	urlObj, err := url.Parse(caDirURL)
-	if urlObj != nil {
-		server = urlObj.Host
-	}
-	metrics.AddACMEAccountRegistration(server, email)
+	metrics.AddACMEAccountRegistration(reg.URI, email)
 
 	return user, nil
 }
@@ -133,5 +127,6 @@ func RegistrationUserFromSecretData(email string, registrationRaw []byte, data m
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling registration json failed with %s", err.Error())
 	}
+	metrics.AddACMEAccountRegistration(reg.URI, email)
 	return &RegistrationUser{Email: email, Registration: reg, key: privateKey}, nil
 }

--- a/pkg/controller/issuer/certificate/backupsecret.go
+++ b/pkg/controller/issuer/certificate/backupsecret.go
@@ -65,6 +65,7 @@ func BackupSecret(res resources.Interface, secret *corev1.Secret, hashKey string
 	resources.SetLabel(backupSecret, LabelCertificateHashKey, hashKey)
 	resources.SetLabel(backupSecret, LabelCertificateKey, "true")
 	resources.SetLabel(backupSecret, LabelCertificateSerialNumber, sn)
+	resources.SetLabel(backupSecret, LabelCertificateBackup, "true")
 	if _, ok := resources.GetAnnotation(secret, AnnotationRevoked); ok {
 		resources.SetAnnotation(backupSecret, AnnotationRevoked, "true")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Metrics have been added for certificate secrets:

- `cert_management_secrets{classification="backup"}` number of certificate secret backups
- `cert_management_secrets{classification="revoked"}` number of revoked certificate secrets
- `cert_management_secrets{classification="total"}` total number of certificate secrets on the cluster

These metrics are only updated on startup and every 24h during GC of outdated secrets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
added metrics for certificate secrets
```
