### PR TITLE
Move type registration to main init

### DIFF
--- a/cmd/cert-controller-manager/main.go
+++ b/cmd/cert-controller-manager/main.go
@@ -20,6 +20,7 @@ import (
 
 	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	ctrl "github.com/gardener/cert-management/pkg/controller"
 	_ "github.com/gardener/cert-management/pkg/controller/issuer"
 	_ "github.com/gardener/cert-management/pkg/controller/source/ingress"
@@ -56,6 +57,7 @@ func init() {
 	resources.Register(extensionsv1beta1.SchemeBuilder)
 	resources.Register(corev1.SchemeBuilder)
 	resources.Register(dnsapi.SchemeBuilder)
+	resources.Register(v1alpha1.SchemeBuilder)
 }
 
 func main() {

--- a/pkg/apis/cert/v1alpha1/register.go
+++ b/pkg/apis/cert/v1alpha1/register.go
@@ -11,8 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/gardener/controller-manager-library/pkg/resources"
-
 	"github.com/gardener/cert-management/pkg/apis/cert"
 )
 
@@ -64,8 +62,4 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
-}
-
-func init() {
-	resources.Register(SchemeBuilder)
 }

--- a/test/functional/basics.go
+++ b/test/functional/basics.go
@@ -13,6 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/cert-management/test/functional/config"
 )
 
@@ -106,6 +108,7 @@ spec:
 `
 
 func init() {
+	resources.Register(v1alpha1.SchemeBuilder)
 	addIssuerTests(functestbasics)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the scheme registration from the `v1alpha1` package to the main initialization functions of the controller.

It mainly eliminates the indirect dependency to the `controller-manager-library` for every component which wants to use the types in `v1alpha1`, e.g. github.com/gardener/gardener-extension-shoot-cert-service.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```