### PR TITLE
tuning timeouts to better deal with long dns propagation for some backends

### DIFF
--- a/pkg/controller/issuer/controller.go
+++ b/pkg/controller/issuer/controller.go
@@ -42,7 +42,7 @@ func init() {
 		DefaultedStringOption(core.OptPrecheckNameservers, "8.8.8.8:53,8.8.4.4:53",
 			"DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf").
 		DefaultedDurationOption(core.OptPrecheckAdditionalWait, 10*time.Second, "additional wait time after DNS propagation check").
-		DefaultedDurationOption(core.OptPropagationTimeout, 60*time.Second, "propagation timeout for DNS challenge").
+		DefaultedDurationOption(core.OptPropagationTimeout, 120*time.Second, "propagation timeout for DNS challenge").
 		DefaultedIntOption(core.OptDefaultRequestsPerDayQuota, 10000,
 			"Default value for requestsPerDayQuota if not set explicitly in the issuer spec.").
 		FinalizerDomain(cert.GroupName).


### PR DESCRIPTION
**What this PR does / why we need it**:
The timeout settings for DNS propagation are too restrictive for Google CloudDNS.
Default dns propagation timeout has been changed from 60s to 120s.
To keep the overall waiting time in a reasonable range, the timeouts of the secondary DNS propagation checks by the lego lib have been reduced.

**Which issue(s) this PR fixes**:
Fixes #64 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
tuning timeouts to better deal with long dns propagation for some DNS backends
```
