### PR TITLE
Update clusterrole to include certificaterevocations

### DIFF
--- a/charts/cert-management/templates/clusterrole.yaml
+++ b/charts/cert-management/templates/clusterrole.yaml
@@ -42,6 +42,8 @@ rules:
   - issuers/status
   - certificates
   - certificates/status
+  - certificaterevocations
+  - certificaterevocations/status
   verbs:
   - get
   - list


### PR DESCRIPTION
**What this PR does / why we need it**:
Experienced errors generating certs in soil for gardener dashboard webterminals

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add certificaterevocations to clusterrole resources
```
