### PR TITLE
changed default type of certificate secret to `kubernetes.io/tls`

### DIFF
--- a/pkg/controller/issuer/certificate/backupsecret.go
+++ b/pkg/controller/issuer/certificate/backupsecret.go
@@ -55,7 +55,9 @@ func BackupSecret(res resources.Interface, secret *corev1.Secret, hashKey string
 		}, false, nil
 	}
 
-	backupSecret := &corev1.Secret{}
+	backupSecret := &corev1.Secret{
+		Type: secret.Type,
+	}
 	backupSecret.GenerateName = fmt.Sprintf("cert-backup-%s-%s-", issuerInfo.Name(), sn[len(sn)-8:])
 	backupSecret.Namespace = metav1.NamespaceSystem
 	backupSecret.Data = secret.Data


### PR DESCRIPTION
**What this PR does / why we need it**:
The default secret type of certificate secrets is changed from `Opaque` to `kubernetes.io/tls` to avoid problems with some client applications like contour.
Already existing certificate secrets will keep their original type, as the secret type is immutable. To change the secret type the secret has to been deleted and a reconciliation of the certificate has to be triggered either by restarting the cert-controller-manager or recreating the certificate object.

**Which issue(s) this PR fixes**:
Fixes #73 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
changed default type of certificate secret to `kubernetes.io/tls`
```
