### PR TITLE
using configmaps and leases for leader election

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,6 @@ Flags:
       --issuer.renewal-window duration                     certificate is renewed if its validity period is shorter of controller issuer
       --issuer.revocations.pool.size int                   Worker pool size for pool revocations of controller issuer
       --issuer.secrets.pool.size int                       Worker pool size for pool secrets of controller issuer
-      --issuer.target-issuers.pool.size int                Worker pool size for pool target-issuers of controller issuer
       --issuers.pool.size int                              Worker pool size for pool issuers
       --kubeconfig string                                  default cluster access
       --kubeconfig.disable-deploy-crds                     disable deployment of required crds for cluster default
@@ -587,6 +586,7 @@ Flags:
       --lease-duration duration                            lease duration
       --lease-name string                                  name for lease object
       --lease-renew-deadline duration                      lease renew deadline
+      --lease-resource-lock string                         determines which resource lock to use for leader election, defaults to 'configmapsleases'
       --lease-retry-period duration                        lease retry period
   -D, --log-level string                                   logrus log level
       --maintainer string                                  maintainer key for crds (default "cert-controller-manager")
@@ -619,7 +619,6 @@ Flags:
       --source.id string                                   id for cluster source
       --source.migration-ids string                        migration id for cluster source
       --target string                                      target cluster for certificates
-      --target-issuers.pool.size int                       Worker pool size for pool target-issuers
       --target-name-prefix string                          name prefix in target namespace for cross cluster generation
       --target-namespace string                            target namespace for cross cluster generation
       --target.disable-deploy-crds                         disable deployment of required crds for cluster target

--- a/charts/cert-management/templates/clusterrole.yaml
+++ b/charts/cert-management/templates/clusterrole.yaml
@@ -15,9 +15,16 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - extensions
   resources:
   - services
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get

--- a/charts/cert-management/templates/deployment.yaml
+++ b/charts/cert-management/templates/deployment.yaml
@@ -202,9 +202,6 @@ spec:
         {{- if .Values.configuration.issuerSecretsPoolSize }}
         - --issuer.secrets.pool.size={{ .Values.configuration.issuerSecretsPoolSize }}
         {{- end }}
-        {{- if .Values.configuration.issuerTargetIssuersPoolSize }}
-        - --issuer.target-issuers.pool.size={{ .Values.configuration.issuerTargetIssuersPoolSize }}
-        {{- end }}
         {{- if .Values.configuration.issuersPoolSize }}
         - --issuers.pool.size={{ .Values.configuration.issuersPoolSize }}
         {{- end }}
@@ -228,6 +225,9 @@ spec:
         {{- end }}
         {{- if .Values.configuration.leaseRenewDeadline }}
         - --lease-renew-deadline={{ .Values.configuration.leaseRenewDeadline }}
+        {{- end }}
+        {{- if .Values.configuration.leaseResourceLock }}
+        - --lease-resource-lock={{ .Values.configuration.leaseResourceLock }}
         {{- end }}
         {{- if .Values.configuration.leaseRetryPeriod }}
         - --lease-retry-period={{ .Values.configuration.leaseRetryPeriod }}
@@ -321,9 +321,6 @@ spec:
         {{- end }}
         {{- if .Values.configuration.target }}
         - --target={{ .Values.configuration.target }}
-        {{- end }}
-        {{- if .Values.configuration.targetIssuersPoolSize }}
-        - --target-issuers.pool.size={{ .Values.configuration.targetIssuersPoolSize }}
         {{- end }}
         {{- if .Values.configuration.targetNamePrefix }}
         - --target-name-prefix={{ .Values.configuration.targetNamePrefix }}

--- a/charts/cert-management/templates/role.yaml
+++ b/charts/cert-management/templates/role.yaml
@@ -30,6 +30,22 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - {{ include "cert-management.fullname" . }}-controllers
+  verbs:
+  - get
+  - watch
+  - update
+- apiGroups:
     - dns.gardener.cloud
   resources:
     - dnsentries

--- a/charts/cert-management/values.yaml
+++ b/charts/cert-management/values.yaml
@@ -86,7 +86,6 @@ configuration:
   # issuerRenewalWindow:
   # issuerRevocationsPoolSize:
   # issuerSecretsPoolSize:
-  # issuerTargetIssuersPoolSize:
   # issuersPoolSize:
   # kubeconfig:
   # kubeconfigDisableDeployCrds:
@@ -95,6 +94,7 @@ configuration:
   # leaseDuration:
   # leaseName:
   # leaseRenewDeadline:
+  # leaseResourceLock:
   # leaseRetryPeriod:
   # logLevel:
   # maintainer:
@@ -126,7 +126,6 @@ configuration:
   # sourceId:
   # sourceMigrationIds:
   # target:
-  # targetIssuersPoolSize:
   # targetNamePrefix:
   # targetNamespace:
   # targetDisableDeployCrds:

--- a/cmd/cert-controller-manager/main.go
+++ b/cmd/cert-controller-manager/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 
@@ -58,6 +59,7 @@ func init() {
 	resources.Register(corev1.SchemeBuilder)
 	resources.Register(dnsapi.SchemeBuilder)
 	resources.Register(v1alpha1.SchemeBuilder)
+	resources.Register(coordinationv1.SchemeBuilder)
 }
 
 func migrateExtensionsIngress(c controllermanager.Configuration) controllermanager.Configuration {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20210611114456-1669e5305832
+	github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876
 	github.com/gardener/external-dns-management v0.7.21
 	github.com/go-acme/lego/v4 v4.1.3
 	github.com/go-openapi/spec v0.19.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20210611114456-1669e5305832 h1:p0d+kbRP5iCvPi5akQL+mkPMAM3T1uaC2DwSkQy28rg=
-github.com/gardener/controller-manager-library v0.2.1-0.20210611114456-1669e5305832/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
+github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876 h1:yCdcUkzFbT4wA0Mn6akB4WRDAe+e1okX48HRahkSNHg=
+github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
 github.com/gardener/external-dns-management v0.7.21 h1:fuRFc2fGs1hkR7CJ3D7IiDplTE5pfuZj+otmTP/YKjc=
 github.com/gardener/external-dns-management v0.7.21/go.mod h1:QJM0IUSQhbK25ftg4ZvFHQuGuT7ScX6Xw4hCxO0j0IM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/config.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/config.go
@@ -11,18 +11,21 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/config"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
 type Config struct {
-	OmitLease          bool
-	LeaseName          string
-	LeaseDuration      time.Duration
-	LeaseRenewDeadline time.Duration
-	LeaseRetryPeriod   time.Duration
+	OmitLease                       bool
+	LeaseName                       string
+	LeaseLeaderElectionResourceLock string
+	LeaseDuration                   time.Duration
+	LeaseRenewDeadline              time.Duration
+	LeaseRetryPeriod                time.Duration
 }
 
 func (this *Config) AddOptionsToSet(set config.OptionSet) {
 	set.AddStringOption(&this.LeaseName, "lease-name", "", "", "name for lease object")
+	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.ConfigMapsLeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'configmapsleases'")
 	set.AddBoolOption(&this.OmitLease, "omit-lease", "", false, "omit lease for development")
 	set.AddDurationOption(&this.LeaseDuration, "lease-duration", "", 15*time.Second, "lease duration")
 	set.AddDurationOption(&this.LeaseRenewDeadline, "lease-renew-deadline", "", 10*time.Second, "lease renew deadline")

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/lease.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/lease.go
@@ -31,7 +31,7 @@ func MakeLeaderElectionConfig(cluster cluster.Interface, namespace string, confi
 		return nil, err
 	}
 	lock, err := resourcelock.New(
-		"configmaps",
+		config.LeaseLeaderElectionResourceLock,
 		namespace,
 		config.LeaseName,
 		client.CoreV1(),

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/syncer.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/syncer.go
@@ -191,9 +191,9 @@ func (this *SyncRequest) update(log logger.LogContext, initiator resources.Objec
 		return false, nil
 	}
 	if this.resourceVersion == "" {
-		log.Infof("synchronizing %s(%s) for %s(%s)", this.name, this.resource, initiator, initiator.GetResourceVersion())
+		log.Infof("synchronizing %s(%s) for %s(%s)", this.name, this.resource, initiator.ClusterKey(), initiator.GetResourceVersion())
 	} else {
-		log.Infof("resynchronizing %s(%s) for %s(%s->%s)", this.name, this.resource, initiator, this.resourceVersion, initiator.GetResourceVersion())
+		log.Infof("resynchronizing %s(%s) for %s(%s->%s)", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion, initiator.GetResourceVersion())
 	}
 	this.resourceVersion = initiator.GetResourceVersion()
 	reconcilers := this.controller.mappings.Get(this.cluster, this.resource.GroupKind())

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,7 +31,7 @@ github.com/evanphx/json-patch/v5
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20210611114456-1669e5305832
+# github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876
 ## explicit
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
The cert-controller-manager now uses both configmaps and leases for leader election.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
using both configmaps and leases for leader election
```
