### PR TITLE
[ACME] Fix account registration on issuer secret update

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder       #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.16.2 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.16.6 AS builder
 
 WORKDIR /build
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/miekg/dns v1.1.31
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	k8s.io/api v0.20.6

--- a/pkg/cert/legobridge/cakeypair.go
+++ b/pkg/cert/legobridge/cakeypair.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -79,7 +78,7 @@ func (c *TLSKeyPair) RawCertInfo() ([]byte, error) {
 
 	certInfo, err := json.Marshal(raw)
 	if err != nil {
-		return nil, errors.Wrap(err, "encoding certificate info failed")
+		return nil, fmt.Errorf("encoding certificate info failed: %w", err)
 	}
 	return certInfo, nil
 }

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/gardener/cert-management/pkg/cert/metrics"
 	"github.com/gardener/cert-management/pkg/cert/utils"
 
@@ -368,7 +366,7 @@ func DecodeCertificate(tlsCrt []byte) (*x509.Certificate, error) {
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("parsing certificate failed with %s", err.Error())
+		return nil, fmt.Errorf("parsing certificate failed: %w", err)
 	}
 	return cert, nil
 }
@@ -415,7 +413,7 @@ func RevokeCertificate(user *RegistrationUser, cert []byte) error {
 	// A client facilitates communication with the CA server.
 	client, err := lego.NewClient(config)
 	if err != nil {
-		return errors.Wrap(err, "client creation failed")
+		return fmt.Errorf("client creation failed: %w", err)
 	}
 
 	return client.Certificate.Revoke(cert)

--- a/pkg/cert/legobridge/reguser.go
+++ b/pkg/cert/legobridge/reguser.go
@@ -140,7 +140,7 @@ func NewRegistrationUserFromEmailAndPrivateKey(issuerKey utils.IssuerKey,
 func (u *RegistrationUser) ToSecretData() (map[string][]byte, error) {
 	privkey, err := privateKeyToBytes(u.key)
 	if err != nil {
-		return nil, fmt.Errorf("encoding private key failed: %s", err.Error())
+		return nil, fmt.Errorf("encoding private key failed: %w", err)
 	}
 	return map[string][]byte{KeyPrivateKey: privkey}, nil
 }
@@ -149,7 +149,7 @@ func (u *RegistrationUser) ToSecretData() (map[string][]byte, error) {
 func (u *RegistrationUser) RawRegistration() ([]byte, error) {
 	reg, err := json.Marshal(u.registration)
 	if err != nil {
-		return nil, fmt.Errorf("encoding registration failed: %s", err.Error())
+		return nil, fmt.Errorf("encoding registration failed: %w", err)
 	}
 	return reg, nil
 }
@@ -169,7 +169,10 @@ func RegistrationUserFromSecretData(issuerKey utils.IssuerKey,
 	reg := &registration.Resource{}
 	err = json.Unmarshal(registrationRaw, reg)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshalling registration json failed with %s", err.Error())
+		return nil, fmt.Errorf("unmarshalling registration json failed: %w", err)
+	}
+	if reg.URI == "" {
+		return nil, fmt.Errorf("unmarshalling registration with unexpected empty URI")
 	}
 	metrics.AddACMEAccountRegistration(issuerKey, reg.URI, email)
 	return &RegistrationUser{email: email, registration: reg, caDirURL: caDirURL, key: privateKey,

--- a/pkg/cert/utils/utils_certificate.go
+++ b/pkg/cert/utils/utils_certificate.go
@@ -99,7 +99,7 @@ func ExtractDomains(spec *api.CertificateSpec) ([]string, error) {
 func ExtractCommonNameAnDNSNames(csr []byte) (cn *string, san []string, err error) {
 	certificateRequest, err := extractCertificateRequest(csr)
 	if err != nil {
-		err = fmt.Errorf("parsing CSR failed with: %s", err)
+		err = fmt.Errorf("parsing CSR failed: %w", err)
 		return
 	}
 	cnvalue := certificateRequest.Subject.CommonName

--- a/pkg/controller/issuer/ca/handler.go
+++ b/pkg/controller/issuer/ca/handler.go
@@ -57,7 +57,7 @@ func (r *caIssuerHandler) Reconcile(logger logger.LogContext, obj resources.Obje
 		issuerKey := r.support.ToIssuerKey(obj.ClusterKey())
 		secret, err = r.support.ReadIssuerSecret(issuerKey, ca.PrivateKeySecretRef)
 		if err != nil {
-			return r.failedCARetry(logger, obj, api.StateError, fmt.Errorf("loading issuer secret failed with %s", err.Error()))
+			return r.failedCARetry(logger, obj, api.StateError, fmt.Errorf("loading issuer secret failed: %w", err))
 		}
 		hash := r.support.CalcSecretHash(secret)
 		r.support.RememberIssuerSecret(obj.ClusterKey(), ca.PrivateKeySecretRef, hash)
@@ -88,13 +88,13 @@ func validateSecretCA(secret *corev1.Secret) ([]byte, error) {
 	// Validate it can be used as a CAKeyPair
 	CAKeyPair, err := legobridge.CAKeyPairFromSecretData(secret.Data)
 	if err != nil {
-		return nil, fmt.Errorf("extracting CA Keypair from secret failed with %s", err.Error())
+		return nil, fmt.Errorf("extracting CA Keypair from secret failed: %w", err)
 	}
 
 	// Validate cert and key are valid and that they match together
 	ok, err := legobridge.ValidatePublicKeyWithPrivateKey(CAKeyPair.Cert.PublicKey, CAKeyPair.Key)
 	if err != nil {
-		return nil, fmt.Errorf("check private key failed with %s", err.Error())
+		return nil, fmt.Errorf("check private key failed: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("private key does not match certificate")
@@ -112,7 +112,7 @@ func validateSecretCA(secret *corev1.Secret) ([]byte, error) {
 
 	CAInfoRaw, err := CAKeyPair.RawCertInfo()
 	if err != nil {
-		return nil, fmt.Errorf("cert info marshalling failed with %s", err.Error())
+		return nil, fmt.Errorf("cert info marshalling failed: %w", err)
 	}
 
 	return CAInfoRaw, nil

--- a/pkg/controller/issuer/core/wrappedregistration.go
+++ b/pkg/controller/issuer/core/wrappedregistration.go
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2019 SAP SE or an SAP affiliate company and Gardener contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package core
+
+import (
+	"encoding/json"
+
+	"github.com/go-acme/lego/v4/registration"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type wrappedRegistration struct {
+	registration.Resource `json:",inline"`
+	SecretHash            *string `json:"secretHash,omitempty"`
+}
+
+// WrapRegistration wraps registration
+func WrapRegistration(raw []byte, secretHash string) ([]byte, error) {
+	reg := &wrappedRegistration{}
+	err := json.Unmarshal(raw, reg)
+	if err != nil {
+		return nil, err
+	}
+	reg.SecretHash = &secretHash
+	return json.Marshal(&reg)
+}
+
+// IsSameExistingRegistration returns true if status ACME has same secret hash
+// or if it has in the old format without secret hash (for migration)
+func IsSameExistingRegistration(raw *runtime.RawExtension, realSecretHash string) bool {
+	if raw == nil || raw.Raw == nil {
+		return false
+	}
+	reg := &wrappedRegistration{}
+	if err := json.Unmarshal(raw.Raw, reg); err == nil && reg.SecretHash != nil {
+		return *reg.SecretHash == realSecretHash
+	}
+	return true
+}

--- a/test/functional/basics.go
+++ b/test/functional/basics.go
@@ -14,8 +14,8 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 
 	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/cert-management/test/functional/config"
+	"github.com/gardener/controller-manager-library/pkg/resources"
 )
 
 var basicTemplate = `
@@ -144,7 +144,7 @@ func functestbasics(cfg *config.Config, iss *config.IssuerConfig) {
 				entryName(iss, "1"): MatchKeys(IgnoreExtras, Keys{
 					"metadata": MatchKeys(IgnoreExtras, Keys{
 						"labels": MatchKeys(IgnoreExtras, Keys{
-							"cert.gardener.cloud/certificate-hash": HavePrefix(""),
+							"cert.gardener.cloud/hash": HavePrefix(""),
 						}),
 					}),
 					"spec": MatchKeys(IgnoreExtras, Keys{

--- a/test/functional/config/config.go
+++ b/test/functional/config/config.go
@@ -98,12 +98,12 @@ func LoadConfig(filename string) (*Config, error) {
 	config := &Config{}
 	err = decoder.Decode(config)
 	if err != nil {
-		return nil, fmt.Errorf("Parsing config file %s failed with %s", filename, err)
+		return nil, fmt.Errorf("Parsing config file %s failed: %w", filename, err)
 	}
 
 	err = config.postProcess()
 	if err != nil {
-		return nil, fmt.Errorf("Post processing config file %s failed with %s", filename, err)
+		return nil, fmt.Errorf("Post processing config file %s failed: %w", filename, err)
 	}
 
 	config.Utils = CreateDefaultTestUtils()

--- a/test/functional/config/utils.go
+++ b/test/functional/config/utils.go
@@ -9,10 +9,11 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/onsi/gomega"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/onsi/gomega"
 )
 
 const STATE_DELETED = "~DELETED~"
@@ -89,7 +90,7 @@ func (u *TestUtils) runCmd(cmdline string) (string, error) {
 	out, err := cmd.Output()
 	if err != nil {
 		println(string(err.(*exec.ExitError).Stderr))
-		return string(out), fmt.Errorf("command `%s` failed with %s", cmdline, err)
+		return string(out), fmt.Errorf("command `%s` failed: %w", cmdline, err)
 	}
 	return string(out), nil
 }
@@ -170,7 +171,7 @@ func (u *TestUtils) AwaitWithTimeout(msg string, check CheckFunc, timeout time.D
 		time.Sleep(u.PollingPeriod)
 	}
 	if err != nil {
-		return fmt.Errorf("Timeout during check %s with error %s", msg, err.Error())
+		return fmt.Errorf("Timeout during check %s with error: %w", msg, err)
 	}
 	return fmt.Errorf("Timeout during check  %s", msg)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -216,7 +216,6 @@ github.com/onsi/gomega/types
 # github.com/pelletier/go-toml v1.8.1
 github.com/pelletier/go-toml
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.7.1
 ## explicit


### PR DESCRIPTION
**What this PR does / why we need it**:
Update of the account registration in the issuer status is not handled correctly if the issuer secret of type `ACME` is updated. 
Besides, the default behaviour is unsuitable for secret rotation, as it triggers an immediate renewal of all certificates.
To allow secret rotation without immediate renewals, all certificate secret hashes are migrated. The new hash includes the issuer key instead of the issuer secret.

Additionally the error handling has been harmonised by replacing `Wrap´ from `github.com/pkg/errors` with `fmt.Errorf("...: %w", err)`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
[ACME] Fix account registration on issuer secret update and allow secret rotation without immediate renewal of certificates. 
```
