### PR TITLE
fix for migration of certificate-hash

### DIFF
--- a/pkg/controller/issuer/acme/handler.go
+++ b/pkg/controller/issuer/acme/handler.go
@@ -75,6 +75,7 @@ func (r *acmeIssuerHandler) Reconcile(logger logger.LogContext, obj resources.Ob
 		}
 		secretHash = r.support.CalcSecretHash(secret)
 		r.support.RememberIssuerSecret(obj.ClusterKey(), acme.PrivateKeySecretRef, secretHash)
+		r.support.RememberAltIssuerSecret(obj.ClusterKey(), acme.PrivateKeySecretRef, secret, acme.Email)
 	}
 	if secret != nil {
 		objKey := obj.ClusterKey()
@@ -121,6 +122,7 @@ func (r *acmeIssuerHandler) Reconcile(logger logger.LogContext, obj resources.Ob
 		acme.PrivateKeySecretRef = secretRef
 		secretHash = r.support.CalcSecretHash(secret)
 		r.support.RememberIssuerSecret(obj.ClusterKey(), acme.PrivateKeySecretRef, secretHash)
+		r.support.RememberAltIssuerSecret(obj.ClusterKey(), acme.PrivateKeySecretRef, secret, acme.Email)
 
 		regRaw, err := user.RawRegistration()
 		if err != nil {

--- a/pkg/controller/issuer/certificate/backupsecret.go
+++ b/pkg/controller/issuer/certificate/backupsecret.go
@@ -86,11 +86,25 @@ func BackupSecret(res resources.Interface, secret *corev1.Secret, hashKey string
 }
 
 // FindAllCertificateSecretsByOldHashLabel get all certificate secrets by the old certificate hash
-func FindAllCertificateSecretsByOldHashLabel(res resources.Interface, hashKey string) ([]resources.Object, error) {
+func FindAllCertificateSecretsByOldHashLabel(res resources.Interface, hashKey, altHashKey string) ([]resources.Object, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", LabelCertificateOldHashKey, hashKey),
 	}
-	return res.List(opts)
+	objs, err := res.List(opts)
+	if err != nil {
+		return nil, err
+	}
+	opts = metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", LabelCertificateOldHashKey, altHashKey),
+	}
+	objs2, err := res.List(opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs2) > 0 {
+		objs = append(objs, objs2...)
+	}
+	return objs, nil
 }
 
 // FindAllCertificateSecretsByNewHashLabel get all certificate secrets by the certificate hash

--- a/pkg/controller/issuer/core/state.go
+++ b/pkg/controller/issuer/core/state.go
@@ -15,6 +15,7 @@ import (
 
 type state struct {
 	secrets      ReferencedSecrets
+	altSecrets   ReferencedSecrets
 	eabSecrets   ReferencedSecrets
 	certificates AssociatedObjects
 	quotas       Quotas
@@ -24,7 +25,7 @@ type state struct {
 }
 
 func newState() *state {
-	return &state{secrets: *NewReferencedSecrets(), eabSecrets: *NewReferencedSecrets(),
+	return &state{secrets: *NewReferencedSecrets(), altSecrets: *NewReferencedSecrets(), eabSecrets: *NewReferencedSecrets(),
 		certificates: *NewAssociatedObjects(), quotas: *NewQuotas(),
 		selections:   *NewIssuerDNSSelections(),
 		overdueCerts: *newObjectNameSet(), revokedCerts: *newObjectNameSet()}
@@ -42,6 +43,7 @@ func (s *state) RemoveIssuer(key utils.IssuerKey) bool {
 	s.certificates.RemoveBySource(key)
 	s.quotas.RemoveIssuer(key)
 	s.eabSecrets.RemoveIssuer(key)
+	s.altSecrets.RemoveIssuer(key)
 	s.selections.Remove(key)
 	return s.secrets.RemoveIssuer(key)
 }
@@ -86,6 +88,18 @@ func (s *state) RememberIssuerSecret(issuer utils.IssuerKey, secretRef *v1.Secre
 
 func (s *state) GetIssuerSecretHash(issuerKey utils.IssuerKey) string {
 	return s.secrets.GetIssuerSecretHash(issuerKey)
+}
+
+// RememberAltIssuerSecret for migration
+// This method is only needed for a bugfix for migrating v0.7.x to v0.8.x an can be deleted after v0.9.0
+func (s *state) RememberAltIssuerSecret(issuer utils.IssuerKey, secretRef *v1.SecretReference, hash string) {
+	s.altSecrets.RememberIssuerSecret(issuer, secretRef, hash)
+}
+
+// GetAltIssuerSecretHash for migration
+// This method is only needed for a bugfix for migrating v0.7.x to v0.8.x an can be deleted after v0.9.0
+func (s *state) GetAltIssuerSecretHash(issuerKey utils.IssuerKey) string {
+	return s.altSecrets.GetIssuerSecretHash(issuerKey)
 }
 
 func (s *state) IssuerNamesForEABSecret(secretKey utils.IssuerSecretKey) utils.IssuerKeySet {


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid requesting new certificates on migration from v0.7.x to v0.8.x for annotated ingress and service resources.
The `Certificate` resource generated for annotated ingress and service resources can loose it labels because of a trigger caused by an update of the issuer secret in the v0.7.x version. An additional migration path has been added to deal with this case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Avoid requesting new certificates on migration from v0.7.x to v0.8.x for annotated ingress and service resources.
```
