### PR TITLE
fix panic on failed secret update on hash migration

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -937,12 +937,12 @@ func (r *certReconciler) migrateSpecHash(logctx logger.LogContext, obj resources
 		return r.failed(logctx, obj, api.StateError, fmt.Errorf("find all certificates by old hash failed: %w", err))
 	}
 
-	for _, obj := range objs {
-		if _, ok := resources.GetLabel(obj.Data(), LabelCertificateNewHashKey); !ok {
-			obj.SetLabels(resources.AddLabel(obj.GetLabels(), LabelCertificateNewHashKey, specNewHash))
-			err = obj.Update()
+	for _, secret := range objs {
+		if _, ok := resources.GetLabel(secret.Data(), LabelCertificateNewHashKey); !ok {
+			secret.SetLabels(resources.AddLabel(secret.GetLabels(), LabelCertificateNewHashKey, specNewHash))
+			err = secret.Update()
 			if err != nil {
-				return r.failed(logctx, obj, api.StateError, fmt.Errorf("updating label for certificate secret %s failed: %w", obj.ObjectName(), err))
+				logctx.Warnf("updating label for certificate secret %s failed: %w", secret.ObjectName(), err)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If during certificate hash migration the update of a secret fails, a panic occurs because of overwritten variable `obj`.

```
Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x1908a00), concrete:(*runtime._type)(0x1968260), asserted:(*runtime._type)(0x194ff00), missingMethod:""} (interface conversion: abstract.ObjectData is *v1.Secret, not *v1alpha1.Certificate)
...
github.com/gardener/cert-management/pkg/controller/issuer/certificate.(*certReconciler).failed(...)
	/build/pkg/controller/issuer/certificate/reconciler.go:1034
github.com/gardener/cert-management/pkg/controller/issuer/certificate.(*certReconciler).migrateSpecHash(0xc000012380, 0x1bd9d40, 0xc0000a89b0, 0x1bec938, 0xc00068c900, 0xc001100400, 0x38, 0xc001100480, 0x38, 0xc0011004c0, ...)
	/build/pkg/controller/issuer/certificate/reconciler.go:945 +0x60a
```

As update failure can only result in a new certificate request, this fix does not fail the migration anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix TypeAssertionError panic on failed secret update on hash migration
```
