### PR TITLE
No panic on failed groupkind migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876
+	github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52
 	github.com/gardener/external-dns-management v0.7.21
 	github.com/go-acme/lego/v4 v4.1.3
 	github.com/go-openapi/spec v0.19.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876 h1:yCdcUkzFbT4wA0Mn6akB4WRDAe+e1okX48HRahkSNHg=
-github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
+github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52 h1:xS8jAUcSpmRj8Axr5cCrMeoTiM1/vIWlNv9Rh1nCD18=
+github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
 github.com/gardener/external-dns-management v0.7.21 h1:fuRFc2fGs1hkR7CJ3D7IiDplTE5pfuZj+otmTP/YKjc=
 github.com/gardener/external-dns-management v0.7.21/go.mod h1:QJM0IUSQhbK25ftg4ZvFHQuGuT7ScX6Xw4hCxO0j0IM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/slavecache.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/slavecache.go
@@ -9,6 +9,7 @@ package resources
 import (
 	"fmt"
 
+	"github.com/gardener/controller-manager-library/pkg/logger"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -64,7 +65,7 @@ func (this *SlaveCache) Setup(slaves []Object) {
 		for _, s := range slaves {
 			err := MigrateGroupKinds(s, this.gkMigration)
 			if err != nil {
-				panic(fmt.Errorf("owner GroupKind migration failed for %s: %s", s.ClusterKey(), err))
+				logger.Errorf("owner GroupKind migration failed for %s: %s", s.ClusterKey(), err)
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,7 +31,7 @@ github.com/evanphx/json-patch/v5
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20210628114606-54e61c158876
+# github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52
 ## explicit
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Under rare circumstances the groupkind migration of certificates (replacing owner references of ingresses from `extensions/v1beta1` to `networking.k8s.io/v1beta1`) fails.
This can happen if the generated certificate has become invalid after its custom resource definition introduced a `maxLength` for the subject.
The panic is avoided with the changes of this PR. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
No panic on failed groupkind migration
```
