### PR TITLE
Support for Kubernetes v1.22

### DIFF
--- a/charts/cert-management/templates/crds-v1.yaml
+++ b/charts/cert-management/templates/crds-v1.yaml
@@ -1,0 +1,640 @@
+# SPDX-FileCopyrightText: 2019 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1") .Values.createCRDs.issuers }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  name: issuers.cert.gardener.cloud
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  group: cert.gardener.cloud
+  names:
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    shortNames:
+      - issuer
+    singular: issuer
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: ACME Server
+          jsonPath: .spec.acme.server
+          name: SERVER
+          type: string
+        - description: ACME Registration email
+          jsonPath: .spec.acme.email
+          name: EMAIL
+          type: string
+        - description: Status of registration
+          jsonPath: .status.state
+          name: STATUS
+          type: string
+        - description: Issuer type
+          jsonPath: .status.type
+          name: TYPE
+          type: string
+        - description: object creation timestamp
+          jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - description: included domains
+          jsonPath: .spec.acme.domains.include
+          name: INCLUDED_DOMAINS
+          priority: 2000
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Issuer is the issuer CR.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IssuerSpec is the spec of the issuer.
+              properties:
+                acme:
+                  description: ACME is the ACME protocol specific spec.
+                  properties:
+                    autoRegistration:
+                      description: AutoRegistration is the flag if automatic registration
+                        should be applied if needed.
+                      type: boolean
+                    domains:
+                      description: Domains optionally specifies domains allowed or forbidden
+                        for certificate requests
+                      properties:
+                        exclude:
+                          description: Exclude are domain names for which certificate
+                            requests are forbidden (including any subdomains)
+                          items:
+                            type: string
+                          type: array
+                        include:
+                          description: Include are domain names for which certificate
+                            requests are allowed (including any subdomains)
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    email:
+                      description: Email is the email address to use for user registration.
+                      type: string
+                    externalAccountBinding:
+                      description: ACMEExternalAccountBinding is a reference to a CA
+                        external account of the ACME server.
+                      properties:
+                        keyID:
+                          description: keyID is the ID of the CA key that the External
+                            Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is the secret ref to the Secret
+                            which holds the symmetric MAC key of the External Account
+                            Binding with data key 'hmacKey'. The secret key stored in
+                            the Secret **must** be un-padded, base64 URL encoded data.
+                          properties:
+                            name:
+                              description: Name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: Namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      type: object
+                    privateKeySecretRef:
+                      description: PrivateKeySecretRef is the secret ref to the ACME
+                        private key.
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    server:
+                      description: Server is the URL of the ACME server.
+                      type: string
+                    skipDNSChallengeValidation:
+                      description: SkipDNSChallengeValidation marks that this issuer
+                        does not validate DNS challenges. In this case no DNS entries/records
+                        are created for a DNS Challenge and DNS propagation is not checked.
+                      type: boolean
+                  required:
+                    - email
+                    - server
+                  type: object
+                ca:
+                  description: CA is the CA specific spec.
+                  properties:
+                    privateKeySecretRef:
+                      description: PrivateKeySecretRef is the secret ref to the CA secret.
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                  type: object
+                requestsPerDayQuota:
+                  description: RequestsPerDayQuota is the maximum number of certificate
+                    requests per days allowed for this issuer
+                  type: integer
+              type: object
+            status:
+              description: IssuerStatus is the status of the issuer.
+              properties:
+                acme:
+                  description: ACME is the ACME specific status.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                ca:
+                  description: CA is the CA specific status.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                message:
+                  description: Message is the status or error message.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the observed generation of the
+                    spec.
+                  format: int64
+                  type: integer
+                requestsPerDayQuota:
+                  description: RequestsPerDayQuota is the actual maximum number of certificate
+                    requests per days allowed for this issuer
+                  type: integer
+                state:
+                  description: State is either empty, 'Pending', 'Error', or 'Ready'.
+                  type: string
+                type:
+                  description: Type is the issuer type. Currently only 'acme' and 'ca'
+                    are supported.
+                  type: string
+              required:
+                - state
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}
+---
+{{- if and (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1") .Values.createCRDs.certificates }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: certificates.cert.gardener.cloud
+spec:
+  group: cert.gardener.cloud
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+      - cert
+    singular: certificate
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Subject domain name of certificate
+          jsonPath: .status.commonName
+          name: COMMON NAME
+          type: string
+        - description: Issuer name
+          jsonPath: .status.issuerRef.name
+          name: ISSUER
+          type: string
+        - description: Status of registration
+          jsonPath: .status.state
+          name: STATUS
+          type: string
+        - description: Expiration date (not valid anymore after this date)
+          jsonPath: .status.expirationDate
+          name: EXPIRATION_DATE
+          priority: 500
+          type: string
+        - description: Domains names in subject alternative names
+          jsonPath: .status.dnsNames
+          name: DNS_NAMES
+          priority: 2000
+          type: string
+        - description: object creation timestamp
+          jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Certificate is the certificate CR.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CertificateSpec is the spec of the certificate to request.
+              properties:
+                commonName:
+                  description: CommonName is the CN for the certificate (max. 64 chars).
+                  maxLength: 64
+                  type: string
+                csr:
+                  description: CSR is the alternative way to provide CN,DNSNames and other information.
+                  format: byte
+                  type: string
+                dnsNames:
+                  description: DNSNames are the optional additional domain names of the certificate.
+                  items:
+                    type: string
+                  type: array
+                ensureRenewedAfter:
+                  description: EnsureRenewedAfter specifies a time stamp in the past. Renewing is only triggered if certificate notBefore date is before this date.
+                  format: date-time
+                  type: string
+                issuerRef:
+                  description: IssuerRef is the reference of the issuer to use.
+                  properties:
+                    name:
+                      description: Name is the name of the issuer (in the configured issuer namespace on default cluster or namespace on target cluster as given).
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the issuer, only needed if issuer is defined on target cluster
+                      type: string
+                  required:
+                    - name
+                  type: object
+                renew:
+                  description: Renew triggers a renewal if set to true
+                  type: boolean
+                secretName:
+                  description: SecretName is the name of the secret object to use for storing the certificate.
+                  type: string
+                secretRef:
+                  description: SecretRef is the reference of the secret object to use for storing the certificate.
+                  properties:
+                    name:
+                      description: Name is unique within a namespace to reference a secret resource.
+                      type: string
+                    namespace:
+                      description: Namespace defines the space within which the secret name must be unique.
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: CertificateStatus is the status of the certificate request.
+              properties:
+                backoff:
+                  description: BackOff contains the state to back off failed certificate requests
+                  properties:
+                    observedGeneration:
+                      description: ObservedGeneration is the observed generation the BackOffState is assigned to
+                      format: int64
+                      type: integer
+                    recheckAfter:
+                      description: RetryAfter is the timestamp this cert request is not retried before.
+                      format: date-time
+                      type: string
+                    recheckInterval:
+                      description: RetryInterval is interval to wait for retrying.
+                      type: string
+                  required:
+                    - recheckAfter
+                    - recheckInterval
+                  type: object
+                commonName:
+                  description: CommonName is the current CN.
+                  type: string
+                dnsNames:
+                  description: DNSNames are the current domain names.
+                  items:
+                    type: string
+                  type: array
+                expirationDate:
+                  description: ExpirationDate shows the notAfter validity date.
+                  type: string
+                issuerRef:
+                  description: IssuerRef is the used issuer.
+                  properties:
+                    cluster:
+                      description: Cluster is the cluster name of the issuer ('default' or 'target'). optional because of backwards compatibility
+                      type: string
+                    name:
+                      description: Name is the name of the issuer.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the issuer.
+                      type: string
+                  required:
+                    - name
+                    - namespace
+                  type: object
+                lastPendingTimestamp:
+                  description: LastPendingTimestamp contains the start timestamp of the last pending status.
+                  format: date-time
+                  type: string
+                message:
+                  description: Message is the status or error message.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the observed generation of the spec.
+                  format: int64
+                  type: integer
+                state:
+                  description: State is the certificate state.
+                  type: string
+              required:
+                - state
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: certificaterevocations.cert.gardener.cloud
+spec:
+  group: cert.gardener.cloud
+  names:
+    kind: CertificateRevocation
+    listKind: CertificateRevocationList
+    plural: certificaterevocations
+    shortNames:
+      - certrevoke
+    singular: certificaterevocation
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Certificate to be revoked
+          jsonPath: .spec.certificateRef.name
+          name: CERTIFICATE
+          type: string
+        - description: status of revocation
+          jsonPath: .status.state
+          name: STATUS
+          type: string
+        - description: timestamp of complete revocation
+          jsonPath: .status.revocationApplied
+          name: REVOKED_AT
+          priority: 500
+          type: date
+        - description: if true certificate objects should be renewed before revoking old certificates certificate(s)
+          jsonPath: .spec.renew
+          name: RENEW
+          type: boolean
+        - description: qualifying all certificates valid before this timestamp
+          jsonPath: .spec.qualifyingDate
+          name: QUALIFIED_AT
+          type: date
+        - description: object creation timestamp
+          jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CertificateRevocation is the certificate revocation custom resource.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CertificateRevocationSpec is the spec of the certificate revocation.
+              properties:
+                certificateRef:
+                  description: CertificateRef is the references to the certificate to be revoked
+                  properties:
+                    name:
+                      description: Name is the name of the certificate in the same namespace.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the certificate CR.
+                      type: string
+                  required:
+                    - name
+                    - namespace
+                  type: object
+                qualifyingDate:
+                  description: QualifyingDate specifies that any certificate with the same DNS names like the given 'certificateRef' should be revoked if it is valid before this date. If not specified, it will be filled with the current time.
+                  format: date-time
+                  type: string
+                renew:
+                  description: Renew specifies if certificate objects should be renewed before revoking old certificates
+                  type: boolean
+              type: object
+            status:
+              description: CertificateRevocationStatus is the status of the certificate request.
+              properties:
+                message:
+                  description: Message is the status or error message.
+                  type: string
+                objects:
+                  description: ObjectStatuses contains the statuses of the involved certificate objects
+                  properties:
+                    failed:
+                      description: Failed is the list of certificate objects whose processing failed
+                      items:
+                        description: CertificateRef is the reference of the issuer by name.
+                        properties:
+                          name:
+                            description: Name is the name of the certificate in the same namespace.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the certificate CR.
+                            type: string
+                        required:
+                          - name
+                          - namespace
+                        type: object
+                      type: array
+                    processing:
+                      description: Processing is the list of certificate objects to be processed
+                      items:
+                        description: CertificateRef is the reference of the issuer by name.
+                        properties:
+                          name:
+                            description: Name is the name of the certificate in the same namespace.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the certificate CR.
+                            type: string
+                        required:
+                          - name
+                          - namespace
+                        type: object
+                      type: array
+                    renewed:
+                      description: Renewed is the list of certificate objects successfully renewed
+                      items:
+                        description: CertificateRef is the reference of the issuer by name.
+                        properties:
+                          name:
+                            description: Name is the name of the certificate in the same namespace.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the certificate CR.
+                            type: string
+                        required:
+                          - name
+                          - namespace
+                        type: object
+                      type: array
+                    revoked:
+                      description: Revoked is the list of certificate objects successfully revoked (without renewal)
+                      items:
+                        description: CertificateRef is the reference of the issuer by name.
+                        properties:
+                          name:
+                            description: Name is the name of the certificate in the same namespace.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the certificate CR.
+                            type: string
+                        required:
+                          - name
+                          - namespace
+                        type: object
+                      type: array
+                  type: object
+                observedGeneration:
+                  description: ObservedGeneration is the observed generation of the spec.
+                  format: int64
+                  type: integer
+                revocationApplied:
+                  description: RevocationApplied is the timestamp when the revocation was completed
+                  format: date-time
+                  type: string
+                secrets:
+                  description: SecretStatuses contains the statuses of the involved certificate secrets
+                  properties:
+                    failed:
+                      description: Failed is the list of certificate secrets whose revocation failed
+                      items:
+                        description: CertificateSecretRef is a reference to a secret together with the serial number
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                          serialNumber:
+                            description: SerialNumber is the serial number of the certificate
+                            type: string
+                        required:
+                          - serialNumber
+                        type: object
+                      type: array
+                    processing:
+                      description: Processing is the list of certificate secrets to be processed
+                      items:
+                        description: CertificateSecretRef is a reference to a secret together with the serial number
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                          serialNumber:
+                            description: SerialNumber is the serial number of the certificate
+                            type: string
+                        required:
+                          - serialNumber
+                        type: object
+                      type: array
+                    revoked:
+                      description: Revoked is the list of certificate secrets successfully revoked
+                      items:
+                        description: CertificateSecretRef is a reference to a secret together with the serial number
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                          serialNumber:
+                            description: SerialNumber is the serial number of the certificate
+                            type: string
+                        required:
+                          - serialNumber
+                        type: object
+                      type: array
+                  type: object
+                state:
+                  description: State is the certificate state.
+                  type: string
+              required:
+                - state
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}

--- a/charts/cert-management/templates/crds-v1beta1.yaml
+++ b/charts/cert-management/templates/crds-v1beta1.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.createCRDs.issuers }}
+{{- if and (not (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1")) .Values.createCRDs.issuers }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -216,7 +216,7 @@ spec:
       storage: true
 {{- end }}
 ---
-{{- if .Values.createCRDs.certificates }}
+{{- if and (not (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1")) .Values.createCRDs.certificates }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/cmd/cert-controller-manager/main.go
+++ b/cmd/cert-controller-manager/main.go
@@ -12,6 +12,7 @@ import (
 
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager"
@@ -56,6 +57,7 @@ func init() {
 		MustRegister()
 
 	resources.Register(networkingv1beta1.SchemeBuilder)
+	resources.Register(networkingv1.SchemeBuilder)
 	resources.Register(corev1.SchemeBuilder)
 	resources.Register(dnsapi.SchemeBuilder)
 	resources.Register(v1alpha1.SchemeBuilder)

--- a/examples/40-ingress-echoheaders.yaml
+++ b/examples/40-ingress-echoheaders.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: echoheaders
@@ -22,6 +22,9 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: echoheaders
-              servicePort: 80
+              service:
+                name: echoheaders
+                port:
+                  number: 80
             path: /
+            pathType: Prefix

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52
+	github.com/gardener/controller-manager-library v0.2.1-0.20210831082646-8ac5ffdda775
 	github.com/gardener/external-dns-management v0.7.21
 	github.com/go-acme/lego/v4 v4.1.3
 	github.com/go-openapi/spec v0.19.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52 h1:xS8jAUcSpmRj8Axr5cCrMeoTiM1/vIWlNv9Rh1nCD18=
-github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
+github.com/gardener/controller-manager-library v0.2.1-0.20210831082646-8ac5ffdda775 h1:9fvyRE5d4rc7jSfA1WzEdSIRZOgD3pEglibNB6FkMDQ=
+github.com/gardener/controller-manager-library v0.2.1-0.20210831082646-8ac5ffdda775/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
 github.com/gardener/external-dns-management v0.7.21 h1:fuRFc2fGs1hkR7CJ3D7IiDplTE5pfuZj+otmTP/YKjc=
 github.com/gardener/external-dns-management v0.7.21/go.mod h1:QJM0IUSQhbK25ftg4ZvFHQuGuT7ScX6Xw4hCxO0j0IM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/apiextensions/versions.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/apiextensions/versions.go
@@ -32,6 +32,7 @@ type CustomResourceDefinitionVersions struct {
 	versioned *utils.Versioned
 }
 
+var v122 = semver.MustParse("1.22.0")
 var v116 = semver.MustParse("1.16.0")
 var v112 = semver.MustParse("1.12.0")
 var otype runtime.Object

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,7 +31,7 @@ github.com/evanphx/json-patch/v5
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20210824121449-a0a838101d52
+# github.com/gardener/controller-manager-library v0.2.1-0.20210831082646-8ac5ffdda775
 ## explicit
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for Kubernetes v1.22 as some apiVersions are not available anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support for Kubernetes v1.22
```
