### PR TITLE
Fix divide by zero on looking up resource quota for uninitialised issuer

### DIFF
--- a/pkg/controller/issuer/core/support.go
+++ b/pkg/controller/issuer/core/support.go
@@ -353,6 +353,8 @@ func (s *Support) Failed(logger logger.LogContext, obj resources.Object, state s
 
 // SucceededAndTriggerCertificates handles succeeded and trigger certificates.
 func (s *Support) SucceededAndTriggerCertificates(logger logger.LogContext, obj resources.Object, itype *string, regRaw []byte) reconcile.Status {
+	s.RememberIssuerQuotas(obj.ClusterKey(), obj.Data().(*api.Issuer).Spec.RequestsPerDayQuota)
+
 	s.reportAllCertificateMetrics()
 	s.triggerCertificates(logger, s.ToIssuerKey(obj.ClusterKey()))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix divide by zero on looking up non-existing resource quota.
This may happen if the certificates reconciliation starts before the issuer is updated.

**Which issue(s) this PR fixes**:
Fixes #91 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix rare divide by zero on looking up resource quota for uninitialised issuer
```
