### PR TITLE
Switch default leader election resource lock to leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ Flags:
       --lease-duration duration                            lease duration
       --lease-name string                                  name for lease object
       --lease-renew-deadline duration                      lease renew deadline
-      --lease-resource-lock string                         determines which resource lock to use for leader election, defaults to 'configmapsleases'
+      --lease-resource-lock string                         determines which resource lock to use for leader election, defaults to 'leases'
       --lease-retry-period duration                        lease retry period
   -D, --log-level string                                   logrus log level
       --maintainer string                                  maintainer key for crds (default "cert-controller-manager")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
-	github.com/gardener/controller-manager-library v0.2.1-0.20210915114933-bfc0604c32c5
+	github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6
 	github.com/gardener/external-dns-management v0.7.21
 	github.com/go-acme/lego/v4 v4.5.3
 	github.com/miekg/dns v1.1.43

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20210915114933-bfc0604c32c5 h1:HOZugGSJkzd/rgSfqgPM8Ku4c1JJMD0rPONWGWl0UkU=
-github.com/gardener/controller-manager-library v0.2.1-0.20210915114933-bfc0604c32c5/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
+github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6 h1:MqtxlnDxgnBnsPk54xwSVpJlQQ6xO429Z0ep4hYwTwo=
+github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
 github.com/gardener/external-dns-management v0.7.21 h1:fuRFc2fGs1hkR7CJ3D7IiDplTE5pfuZj+otmTP/YKjc=
 github.com/gardener/external-dns-management v0.7.21/go.mod h1:QJM0IUSQhbK25ftg4ZvFHQuGuT7ScX6Xw4hCxO0j0IM=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=

--- a/test/functional/run.sh
+++ b/test/functional/run.sh
@@ -194,7 +194,7 @@ fi
 
 if [ "$RUN_CONTROLLER" == "true" ]; then
   go build -mod=vendor -o $ROOTDIR/cert-controller-manager $ROOTDIR/cmd/cert-controller-manager
-  $ROOTDIR/cert-controller-manager --dns $DNS_KUBECONFIG >/dev/null 2>&1 &
+  $ROOTDIR/cert-controller-manager --dns $DNS_KUBECONFIG >/tmp/functest-cert-controller-manager.log 2>&1 &
   PID_CONTROLLER=$!
 fi
 

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
@@ -37,7 +37,7 @@ type Environment interface {
 }
 
 type Pool interface {
-	StartTicker()
+	Tick()
 	EnqueueCommand(name string)
 	EnqueueCommandRateLimited(name string)
 	EnqueueCommandAfter(name string, duration time.Duration)

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/config.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/config.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func (this *Config) AddOptionsToSet(set config.OptionSet) {
 	set.AddStringOption(&this.LeaseName, "lease-name", "", "", "name for lease object")
-	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.ConfigMapsLeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'configmapsleases'")
+	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.LeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'leases'")
 	set.AddBoolOption(&this.OmitLease, "omit-lease", "", false, "omit lease for development")
 	set.AddDurationOption(&this.LeaseDuration, "lease-duration", "", 15*time.Second, "lease duration")
 	set.AddDurationOption(&this.LeaseRenewDeadline, "lease-renew-deadline", "", 10*time.Second, "lease renew deadline")

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/pool.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/pool.go
@@ -148,8 +148,8 @@ func (p *pool) Period() time.Duration {
 	return p.period
 }
 
-func (p *pool) StartTicker() {
-	// noop as periodic tick is always activated
+func (p *pool) Tick() {
+	healthz.Tick(p.Key())
 }
 
 func (p *pool) Run() {

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/abstract/resources.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/abstract/resources.go
@@ -191,7 +191,12 @@ func (this *AbstractResources) _newResource(gvk schema.GroupVersionKind, otype r
 		return nil, errors.New(errors.ERR_NO_LIST_TYPE, "cannot determine list type for %s", otype)
 	}
 
-	return this.newResource(this.self, gvk, otype, ltype)
+	resource, err := this.newResource(this.self, gvk, otype, ltype)
+	if err != nil {
+		return nil, err
+	}
+	this.handlersByObjType[otype] = resource
+	return resource, nil
 }
 
 type getResource func(gvk schema.GroupVersionKind) (Resource, error)

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/subcache.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/subcache.go
@@ -98,7 +98,7 @@ func (this *SubObjectCache) GetSubObject(key ClusterObjectKey) Object {
 	if o == nil {
 		return nil
 	}
-	return o.object
+	return o.object.DeepCopy()
 }
 
 func (this *SubObjectCache) GetOwners(key ClusterObjectKey, kinds ...schema.GroupKind) ClusterObjectKeySet {
@@ -215,7 +215,7 @@ func (this *SubObjectCache) GetByOwnerKey(key ClusterObjectKey) []Object {
 	keys := this.byOwner[key]
 	result := []Object{}
 	for k := range keys {
-		result = append(result, this.subObjects[k].object)
+		result = append(result, this.subObjects[k].object.DeepCopy())
 	}
 	return result
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,7 +44,7 @@ github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 ## explicit; go 1.13
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20210915114933-bfc0604c32c5
+# github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6
 ## explicit; go 1.16
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch default leader election resource lock from `configmapsleases` to `leases`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switch default leader election resource lock from `configmapsleases` to `leases`
```
