### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,14 +11,12 @@ COPY . .
 RUN make release
 
 ############# base
-FROM alpine:3.16.0 AS base
+FROM gcr.io/distroless/static-debian11:nonroot AS base
 
 #############      cert-controller-manager     #############
 FROM base AS cert-controller-manager
 
-RUN addgroup -S app && adduser -S -G app app
 WORKDIR /
 COPY --from=builder /build/cert-controller-manager /cert-controller-manager
-USER app
 
 ENTRYPOINT ["/cert-controller-manager"]


### PR DESCRIPTION
/area open-source security
/kind enhancement

**What this PR does / why we need it**:
This PR changes the base image for `cert-controller-manager` from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). This will reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `cert-controller-manager` now uses `distroless` instead of `alpine` as a base image.
```
