### PR TITLE
Update builder image from golang:v1.18.5 to v1.19.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder       #############
-FROM golang:1.18.5 AS builder
+FROM golang:1.19.2 AS builder
 
 WORKDIR /build
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/cert-management
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0

--- a/hack/check-cert-secret.sh
+++ b/hack/check-cert-secret.sh
@@ -50,7 +50,7 @@ prepareParts()
 {
     mkdir -p "$PREFIX"
     # extract certificate from certificate secret
-    kubectl -n $NS get secret $(kubectl -n $NS get cert $CERTNAME  -o=jsonpath='{.spec.secretRef.name}') -o=jsonpath='{.data.tls\.crt}' | base64 -d > "$X509CERT"
+    kubectl -n $NS get secret $(kubectl -n $NS get certificates.cert.gardener.cloud $CERTNAME  -o=jsonpath='{.spec.secretRef.name}') -o=jsonpath='{.data.tls\.crt}' | base64 -d > "$X509CERT"
 
     # split certificate and chain
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder image from golang:v1.18.5 to v1.19.2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update builder image from `golang:1.18.5` to `golang:1.19.2`
```
