### PR TITLE
Fix FindIssuerKeyByName (binding per-loop bug)

### DIFF
--- a/pkg/controller/issuer/core/support.go
+++ b/pkg/controller/issuer/core/support.go
@@ -471,7 +471,7 @@ func (s *Support) IssuerClusterObjectKey(certNamespace string, spec *api.Certifi
 	return utils.NewDefaultClusterIssuerKey(s.defaultIssuerName)
 }
 
-// FindIssuerKeyByName tries to find a issuer key on target or default cluster
+// FindIssuerKeyByName tries to find an issuer key on target or default cluster
 func (s *Support) FindIssuerKeyByName(namespace, issuerName string) *utils.IssuerKey {
 	var bestKey *utils.IssuerKey
 	var bestFit int
@@ -485,7 +485,8 @@ func (s *Support) FindIssuerKeyByName(namespace, issuerName string) *utils.Issue
 				}
 			}
 			if fit > bestFit {
-				bestKey = &key
+				k := key
+				bestKey = &k
 				bestFit = fit
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the method FindIssuerKeyByName caused by the "binding per-loop" instead of "binding per-iteration" of for loops in Go.
As a consequence of this bug, a seemingly random issuer was selected if there have been multiple issuers.

**Which issue(s) this PR fixes**:
Fixes #113

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix for correct issuer selection by name.
```
