### PR TITLE
Fix cert.gardener.cloud/issuer annotation for shoot issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ See also [examples/40-ingress-echoheaders.yaml](./examples/40-ingress-echoheader
         #cert.gardener.cloud/dnsnames: "" # optional, if not specified the names from spec.tls[].hosts are used
         #cert.gardener.cloud/follow-cname: "true" # optional, to activate CNAME following for the DNS challenge
         #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
+        #cert.gardener.cloud/issuer: issuer-name # optional to specify custom issuer (use namespace/name for shoot issuers)
     spec:
       tls:
         - hosts:
@@ -503,6 +504,7 @@ metadata:
     #cert.gardener.cloud/dnsnames: "" # optional, if specified overrides dns.gardener.cloud/dnsnames annotation for certificate names
     #cert.gardener.cloud/follow-cname: "true" # optional, to activate CNAME following for the DNS challenge
     #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
+    #cert.gardener.cloud/issuer: issuer-name # optional to specify custom issuer (use namespace/name for shoot issuers)
     dns.gardener.cloud/ttl: "600"
   name: test-service
   namespace: default

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder       #############
-FROM golang:1.20.5 AS builder
+FROM golang:1.20.6 AS builder
 
 WORKDIR /build
 COPY . .

--- a/examples/30-cert-simple.yaml
+++ b/examples/30-cert-simple.yaml
@@ -17,6 +17,8 @@ spec:
   # if issuer is not specified, the default issuer is used
   issuerRef:
     name: issuer-staging
+    # for shoot issuers, the namespace must be specified
+    #namespace: my-ns
   # optionally specify secret to store certificate
   secretRef:
     name: cert-simple-secret

--- a/examples/40-ingress-echoheaders.yaml
+++ b/examples/40-ingress-echoheaders.yaml
@@ -14,6 +14,7 @@ metadata:
     #cert.gardener.cloud/dnsnames: "" # optional, if not specified the names from spec.tls[].hosts are used
     #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates
     #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
+    #cert.gardener.cloud/issuer: issuer-name # optional to specify custom issuer (use namespace/name for shoot issuers)
 spec:
   tls:
     - hosts:

--- a/examples/40-service-loadbalancer.yaml
+++ b/examples/40-service-loadbalancer.yaml
@@ -14,6 +14,7 @@ metadata:
     #cert.gardener.cloud/dnsnames: "" # optional, if specified overrides dns.gardener.cloud/dnsnames annotation for certificate names
     #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates
     #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
+    #cert.gardener.cloud/issuer: issuer-name # optional to specify custom issuer (use namespace/name for shoot issuers)
   name: test-service
   namespace: default
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
For custom issuers you have to specify the annotation `cert.gardener.cloud/issuer annotation` for managed resources like `Ingress` and `Service`.
For shoot issuers (option `--allow-target-issuers`) you have to provide both namespace and name in this case, but the source controller did not deal correctly with it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Allow to specify shoot issuer in annotation `cert.gardener.cloud/issuer annotation` with format `namespace/name`.
```

```other operator
Updated builder image from `golang:1.20.5` to `golang:1.20.6`
