### PR TITLE
Add helm labels to CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test:
 generate:
 	@./hack/generate-code
 	@GO111MODULE=on go generate ./pkg/apis/cert/...
-	cp ./pkg/apis/cert/crds/*.yaml ./charts/cert-management/templates/
+	@./hack/copy-crds.sh
 
 .PHONY: docker-images
 docker-images:

--- a/charts/cert-management/templates/cert.gardener.cloud_certificaterevocations.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificaterevocations.yaml
@@ -3,6 +3,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null

--- a/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
@@ -3,6 +3,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null

--- a/charts/cert-management/templates/cert.gardener.cloud_issuers.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_issuers.yaml
@@ -3,6 +3,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    helm.sh/chart: {{ include "cert-management.chart" . }}
+    app.kubernetes.io/name: {{ include "cert-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null

--- a/hack/copy-crds.sh
+++ b/hack/copy-crds.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+set -e
+
+source_dir="$(dirname "$0")/../pkg/apis/cert/crds"
+destination_dir="$(dirname "$0")/../charts/cert-management/templates/"
+
+# Function to update the metadata section and copy to destination
+update_and_copy() {
+    local source_file="$1"
+    local dest_file="$destination_dir/$(basename "$source_file")"
+
+    # Use awk to update the metadata and copy to destination
+    awk '/^metadata:/ {
+        print
+        metadata_found = 1
+        if ($0 == "metadata:") {
+            print "  labels:"
+            print "    helm.sh/chart: {{ include \"cert-management.chart\" . }}"
+            print "    app.kubernetes.io/name: {{ include \"cert-management.name\" . }}"
+            print "    app.kubernetes.io/instance: {{ .Release.Name }}"
+            print "    app.kubernetes.io/managed-by: {{ .Release.Service }}"
+        }
+        next
+    }
+    metadata_found == 1 { metadata_found = 0 }
+    {print}' "$source_file" > "$dest_file"
+}
+
+# Iterate through each YAML file in the source directory
+for source_file in "$source_dir"/*.yaml; do
+    if [ -f "$source_file" ]; then
+        update_and_copy "$source_file"
+    fi
+done


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds back the helm labels to CRDs removed in https://github.com/gardener/cert-management/pull/133.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
