### PR TITLE
Fix edge case of inconsistent certificate/secret: request certificate in this case

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -240,7 +240,7 @@ func (r *certReconciler) reconcileCert(logctx logger.LogContext, obj resources.O
 			}
 			// ignore if SecretRef is specified but not existing
 			// will later be used to store the secret
-		} else {
+		} else if x509cert, err := legobridge.DecodeCertificateFromSecretData(secret.Data); err == nil {
 			if storedHash := cert.Labels[LabelCertificateNewHashKey]; storedHash != "" {
 				specHash := r.buildSpecNewHash(&cert.Spec, issuerKey)
 				if specHash != storedHash {
@@ -268,8 +268,7 @@ func (r *certReconciler) reconcileCert(logctx logger.LogContext, obj resources.O
 			}
 
 			// corner case: existing secret but no stored hash, check if renewal is overdue
-			x509cert, err := legobridge.DecodeCertificateFromSecretData(secret.Data)
-			if err == nil && r.isRenewalOverdue(x509cert) {
+			if r.isRenewalOverdue(x509cert) {
 				r.support.SetCertRenewalOverdue(obj.ObjectName())
 			}
 		}

--- a/test/functional/basics.go
+++ b/test/functional/basics.go
@@ -119,6 +119,26 @@ spec:
   secretLabels:
     foo: bar
     some.gardener.cloud/thing: "true"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert4-secret
+  namespace: {{.Namespace}}
+type: Opaque
+---
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: Certificate
+metadata:
+  name: cert4
+  namespace: {{.Namespace}}
+  labels:
+    cert.gardener.cloud/hash: a74c0e0a617fd1499cddac5136b8e09e3ca30edd4f173f7e73d8910b
+spec:
+  commonName: cert4.{{.Domain}}
+  secretName: cert4-secret
+  issuerRef:
+    name: {{.Name}}
 `
 
 var revoke2Template = `
@@ -283,6 +303,11 @@ func functestbasics(cfg *config.Config, iss *config.IssuerConfig) {
 				Ω(err).Should(BeNil())
 				Ω(secret.Labels["foo"]).Should(Equal("bar"))
 				Ω(secret.Labels["some.gardener.cloud/thing"]).Should(Equal("true"))
+			})
+
+			By("check starting from invalid state in cert4", func() {
+				err = u.AwaitCertReady("cert4")
+				Ω(err).Should(BeNil())
 			})
 
 			By("revoking without renewal", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an edge case of an inconsistent certificate: If the certificate has certificate hash labels but the secret is empty, a new certificate is requested now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix edge case of inconsistent certificate/secret: request certificate in this case.
```
