### PR TITLE
Disable followCNAME by default again

### DIFF
--- a/cmd/cert-controller-manager/main.go
+++ b/cmd/cert-controller-manager/main.go
@@ -74,5 +74,7 @@ func main() {
 		fmt.Println(version)
 		os.Exit(0)
 	}
+	// set LEGO_DISABLE_CNAME_SUPPORT=true as we have our own logic for FollowCNAME
+	os.Setenv("LEGO_DISABLE_CNAME_SUPPORT", "true")
 	controllermanager.Start("cert-controller-manager", "Certificate controller manager", "nothing", migrateExtensionsIngress)
 }

--- a/pkg/cert/legobridge/dnscontrollerprovider.go
+++ b/pkg/cert/legobridge/dnscontrollerprovider.go
@@ -115,7 +115,9 @@ func retryOnUpdateError(fn func() error) error {
 func (p *dnsControllerProvider) Present(domain, token, keyAuth string) error {
 	metrics.AddActiveACMEDNSChallenge(p.issuerKey)
 	atomic.AddInt32(&p.count, 1)
-	fqdn, value := dns01.GetRecord(domain, keyAuth)
+	info := dns01.GetChallengeInfo(domain, keyAuth)
+	value := info.Value
+	fqdn := info.FQDN
 
 	if p.settings.FollowCNAME {
 		var err error


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable followCNAME by default again, as it was introduced with github.com/go-acme/lego version upgrade from `v4.8.0` to `v4.14.0`(Introduced with https://github.com/go-acme/lego/pull/1718)

**Which issue(s) this PR fixes**:
Fixes #139 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disable followCNAME by default again as it was activated implicitly by github.com/go-acme/lego version upgrade
```
