### PR TITLE
Remove short name for issuer

### DIFF
--- a/charts/cert-management/templates/cert.gardener.cloud_issuers.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_issuers.yaml
@@ -16,8 +16,6 @@ spec:
     kind: Issuer
     listKind: IssuerList
     plural: issuers
-    shortNames:
-    - issuer
     singular: issuer
   scope: Namespaced
   versions:

--- a/pkg/apis/cert/crds/cert.gardener.cloud_issuers.yaml
+++ b/pkg/apis/cert/crds/cert.gardener.cloud_issuers.yaml
@@ -11,8 +11,6 @@ spec:
     kind: Issuer
     listKind: IssuerList
     plural: issuers
-    shortNames:
-    - issuer
     singular: issuer
   scope: Namespaced
   versions:

--- a/pkg/apis/cert/crds/zz_generated_crds.go
+++ b/pkg/apis/cert/crds/zz_generated_crds.go
@@ -670,8 +670,6 @@ spec:
     kind: Issuer
     listKind: IssuerList
     plural: issuers
-    shortNames:
-    - issuer
     singular: issuer
   scope: Namespaced
   versions:

--- a/pkg/apis/cert/v1alpha1/types.go
+++ b/pkg/apis/cert/v1alpha1/types.go
@@ -328,7 +328,7 @@ type IssuerList struct {
 // Issuer is the issuer CR.
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced,path=issuers,shortName=issuer,singular=issuer
+// +kubebuilder:resource:scope=Namespaced,path=issuers,singular=issuer
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name=SERVER,description="ACME Server",JSONPath=".spec.acme.server",type=string
 // +kubebuilder:printcolumn:name=EMAIL,description="ACME Registration email",JSONPath=".spec.acme.email",type=string


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-cert-service/issues/208

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove `issuer` short name for issuer CustomResourceDefinition as it is the same as the singular.
```
