### PR TITLE
Prepare gcr to ar

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,7 +24,7 @@ cert-management:
         image: golang:1.21.5
         output_dir: binary
       check:
-        image: golang:1.20.2
+        image: golang:1.21.5
       test:
         image: golang:1.21.5
 

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -26,7 +26,7 @@ cert-management:
       check:
         image: golang:1.20.2
       test:
-        image: golang:1.20.2
+        image: golang:1.21.5
 
   jobs:
     head-update:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,14 +5,44 @@ cert-management:
   base_definition:
     traits:
       version:
-        preprocess: 'inject-commit-hash'
+        preprocess: inject-branch-name
+        inject_effective_version: true
       component_descriptor: ~
+      publish:
+        dockerimages:
+          cert-management:
+            dockerfile: build/Dockerfile
+            image: eu.gcr.io/gardener-project/cert-controller-manager
+            inputs:
+              repos:
+                source: ~
+              steps:
+                build: ~
+
+    steps:
+      build:
+        image: golang:1.20.2
+        output_dir: binary
+      check:
+        image: golang:1.20.2
+      test:
+        image: golang:1.20.2
+
   jobs:
     head-update:
       traits:
         draft_release: ~
+        version:
+          preprocess: inject-commit-hash
         component_descriptor:
           retention_policy: 'clean-snapshots'
+
+    pull-request:
+      traits:
+        pull-request: ~
+        version:
+          preprocess: inject-commit-hash
+
     release:
       traits:
         version:
@@ -27,6 +57,7 @@ cert-management:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
+
     patch-release:
       traits:
         version:
@@ -35,3 +66,23 @@ cert-management:
           nextversion: bump_patch
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+        slack:
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: C9CEBQPGE
+              slack_cfg_name: scp_workspace
+          default_channel: internal_scp_workspace
+
+    verbatim-release:
+      traits:
+        release:
+          nextversion: noop
+          release_callback: .ci/prepare_release
+        slack:
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: C9CEBQPGE
+              slack_cfg_name: scp_workspace
+          default_channel: internal_scp_workspace
+        version:
+          preprocess: noop

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 cert-management:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess: 'inject-commit-hash'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,7 +21,7 @@ cert-management:
 
     steps:
       build:
-        image: golang:1.20.2
+        image: golang:1.21.5
         output_dir: binary
       check:
         image: golang:1.20.2


### PR DESCRIPTION
**What this PR does / why we need it**

Refactor .ci/pipeline_definitions in preparations for subsequent switch from GCR -> Artifact-Registry. This change will as a side-effect make managing pipeline-definition slightly less cumbersome.

Accepting this change will have no immediate effect. Therefore, no release-notes are deemed necessary.