### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,12 +7,13 @@ cert-management:
       version:
         preprocess: inject-branch-name
         inject_effective_version: true
-      component_descriptor: ~
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         dockerimages:
           cert-management:
             dockerfile: build/Dockerfile
-            image: eu.gcr.io/gardener-project/cert-controller-manager
+            image: europe-docker.pkg.dev/gardener-project/snapshots/cert-controller-manager
             inputs:
               repos:
                 source: ~
@@ -36,6 +37,8 @@ cert-management:
           preprocess: inject-commit-hash
         component_descriptor:
           retention_policy: 'clean-snapshots'
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
 
     pull-request:
       traits:
@@ -47,10 +50,16 @@ cert-management:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+        publish:
+          dockerimages:
+            cert-management:
+              image: europe-docker.pkg.dev/gardener-project/releases/cert-controller-manager
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:
@@ -62,6 +71,12 @@ cert-management:
       traits:
         version:
           preprocess: finalize
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            cert-management:
+              image: europe-docker.pkg.dev/gardener-project/releases/cert-controller-manager
         release:
           nextversion: bump_patch
           next_version_callback: '.ci/prepare_release'
@@ -78,6 +93,12 @@ cert-management:
         release:
           nextversion: noop
           release_callback: .ci/prepare_release
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            cert-management:
+              image: europe-docker.pkg.dev/gardener-project/releases/cert-controller-manager
         slack:
           channel_cfgs:
             internal_scp_workspace:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-REGISTRY              := eu.gcr.io/gardener-project
+REGISTRY              :=  europe-docker.pkg.dev/gardener-project/public
 EXECUTABLE            := cert-controller-manager
 REPO_ROOT             := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 PROJECT               := github.com/gardener/cert-management

--- a/charts/cert-management/values.yaml
+++ b/charts/cert-management/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: cert-controller-manager
 replicaCount: 1
 
 image:
-  repository: eu.gcr.io/gardener-project/cert-controller-manager
+  repository: europe-docker.pkg.dev/gardener-project/public/cert-controller-manager
   tag: v0.11.4-master
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
