### PR TITLE
Using common code generation scripts

### DIFF
--- a/hack/generate-code
+++ b/hack/generate-code
@@ -6,30 +6,28 @@
 
 set -e
 
-rm -f ${GOPATH}/bin/*-gen
-
 SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
 
 rm -rf "$SOURCE_PATH/pkg/client/cert"
 
 # setup virtual GOPATH
 source "$CONTROLLER_MANAGER_LIB_HACK_DIR"/vgopath-setup.sh
-trap 'rm -rf "$VIRTUAL_GOPATH"; rm -rf $REPO_ROOT/vendor' EXIT
 
-go mod vendor
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SOURCE_PATH}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
-source "${CODEGEN_PKG}/kube_codegen.sh"
+CODE_GEN_DIR=$(go list -m -f '{{.Dir}}' k8s.io/code-generator)
 
-PKGPATH=github.com/gardener/cert-management
+rm -f ${GOPATH}/bin/*-gen
 
-kube::codegen::gen_helpers \
-  --input-pkg-root $PKGPATH/pkg/apis \
-  --output-base "${SOURCE_PATH}/../../.." \
-  --boilerplate "${SOURCE_PATH}/hack/LICENSE_BOILERPLATE.txt"
+# We need to explicitly pass GO111MODULE=off to k8s.io/code-generator as it is significantly slower otherwise,
+# see https://github.com/kubernetes/code-generator/issues/100.
+export GO111MODULE=off
 
-kube::codegen::gen_client \
-    --with-watch \
-    --input-pkg-root $PKGPATH/pkg/apis \
-    --output-pkg-root $PKGPATH/pkg/client/cert \
-    --output-base "${SOURCE_PATH}/../../.." \
-    --boilerplate "${SOURCE_PATH}/hack/LICENSE_BOILERPLATE.txt"
+rm -rf "${SOURCE_PATH}/pkg/client/cert"
+PROJECT_ROOT=$(dirname $0)/..
+
+bash "${CODE_GEN_DIR}"/generate-internal-groups.sh \
+  "deepcopy,client,informer,lister" \
+  github.com/gardener/cert-management/pkg/client/cert \
+  "" \
+  github.com/gardener/cert-management/pkg/apis \
+  "cert:v1alpha1" \
+  --go-header-file "${SOURCE_PATH}/hack/LICENSE_BOILERPLATE.txt"


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts usage of "kube::codegen::gen_*" scripts introduced in #142 to be comparable to other Gardener projects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
