### PR TITLE
Fix updateEntry for first domain len > 64

### DIFF
--- a/pkg/cert/source/reconciler.go
+++ b/pkg/cert/source/reconciler.go
@@ -397,8 +397,13 @@ func (r *sourceReconciler) updateEntry(logger logger.LogContext, info CertInfo, 
 		var cn *string
 		var dnsNames []string
 		if len(info.Domains) > 0 {
-			cn = &info.Domains[0]
-			dnsNames = info.Domains[1:]
+			if len(info.Domains[0]) <= 64 {
+				cn = &info.Domains[0]
+				dnsNames = info.Domains[1:]
+			} else {
+				cn = nil
+				dnsNames = info.Domains
+			}
 		}
 
 		mod.AssureStringPtrPtr(&spec.CommonName, cn)

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -771,10 +771,10 @@ func (r *certReconciler) buildSpecNewHash(spec *api.CertificateSpec, issuerKey u
 	if spec.CommonName != nil {
 		h.Write([]byte(*spec.CommonName))
 		h.Write([]byte{0})
-		for _, domain := range spec.DNSNames {
-			h.Write([]byte(domain))
-			h.Write([]byte{0})
-		}
+	}
+	for _, domain := range spec.DNSNames {
+		h.Write([]byte(domain))
+		h.Write([]byte{0})
 	}
 	if spec.CSR != nil {
 		h.Write([]byte{0})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for certificates without common name (if first domain name is longer than 64 characters). On updating existing source objects, the certificates the commonName was filled wrongly.
Additionally the hashcode calculation was wrong if common name was not filled.
Fix for new bug introduced with with #150.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Updating source objects (like Ingress or Service) with first domain name longer than 64 character failed, as the commonName field was filled in the updated certificate object. It must be left empty in this case.
```
