### PR TITLE
Fix cluster configuration for new source controllers

### DIFF
--- a/pkg/controller/source/gateways/crdwatch/controller.go
+++ b/pkg/controller/source/gateways/crdwatch/controller.go
@@ -23,6 +23,7 @@ const Controller = "watch-gateways-crds"
 func init() {
 	controller.Configure(Controller).
 		Reconciler(Create).
+		Cluster(ctrl.SourceCluster).
 		DefaultWorkerPool(1, 0*time.Second).
 		MainResource(apiextensionsv1.GroupName, "CustomResourceDefinition").
 		MustRegister(ctrl.ControllerGroupSource)

--- a/pkg/controller/source/gateways/gatewayapi/controller.go
+++ b/pkg/controller/source/gateways/gatewayapi/controller.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	ctrl "github.com/gardener/cert-management/pkg/controller"
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 
 	"github.com/gardener/cert-management/pkg/cert/source"
@@ -26,10 +25,10 @@ var (
 
 func init() {
 	source.CertSourceController(source.NewCertSourceTypeForCreator("k8s-gateways-dns", GroupKindGateway, NewGatewaySource), nil).
-		FinalizerDomain("dns.gardener.cloud").
+		FinalizerDomain("cert.gardener.cloud").
+		RequireLease(ctrl.SourceCluster).
 		DeactivateOnCreationErrorCheck(deactivateOnMissingMainResource).
 		Reconciler(httpRoutesReconciler, "httproutes").
-		Cluster(cluster.DEFAULT).
 		WorkerPool("httproutes", 2, 0).
 		ReconcilerWatchesByGK("httproutes", GroupKindHTTPRoute).
 		MustRegister(ctrl.ControllerGroupSource)

--- a/pkg/controller/source/gateways/istio/controller.go
+++ b/pkg/controller/source/gateways/istio/controller.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gardener/cert-management/pkg/controller/source/ingress"
 	"github.com/gardener/cert-management/pkg/controller/source/service"
 
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 )
 
@@ -25,11 +24,11 @@ var (
 
 func init() {
 	source.CertSourceController(source.NewCertSourceTypeForCreator("istio-gateways-dns", GroupKindGateway, newGatewaySource), nil).
-		FinalizerDomain("dns.gardener.cloud").
+		FinalizerDomain("cert.gardener.cloud").
+		RequireLease(ctrl.SourceCluster).
 		DeactivateOnCreationErrorCheck(deactivateOnMissingMainResource).
 		Reconciler(newTargetSourcesReconciler, "targetsources").
 		Reconciler(newVirtualServicesReconciler, "virtualservices").
-		Cluster(cluster.DEFAULT).
 		WorkerPool("targetsources", 2, 0).
 		ReconcilerWatchesByGK("targetsources", service.MainResource, ingress.MainResource).
 		WorkerPool("virtualservices", 2, 0).


### PR DESCRIPTION
**What this PR does / why we need it**:
For multi-cluster deployments, the new source controllers `istio-gateways-dns` and `k8s-gateways-dns` did watch on the default cluster, but the must watch on the source cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix cluster configuration for new source controllers `istio-gateways-dns` and `k8s-gateways-dns`.
```
