### PR TITLE
Fix regression for annotations on ingress resources

### DIFF
--- a/pkg/controller/source/helper.go
+++ b/pkg/controller/source/helper.go
@@ -70,7 +70,7 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 		}
 	}
 
-	annotatedDomains, cn := source.GetDomainsFromAnnotations(objData)
+	annotatedDomains, cn := source.GetDomainsFromAnnotations(objData, false)
 
 	var issuer *string
 	annotatedIssuer, ok := resources.GetAnnotation(objData, source.AnnotIssuer)


### PR DESCRIPTION
**What this PR does / why we need it**:
On refactoring, the code for annotation handling for services and ingresses has been unified. There is an edge case for services, that the `dns.gardener.cloud/dnsnames` annotation is considered for services, but must not be considered for ingresses. This distinction has gone lost.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix regression for annotations on ingress resources: `dns.gardener.cloud/dnsnames` annotation must be ignored.
```
