### PR TITLE
fix creating certificates with a given csr referencing a ca issuer

### DIFF
--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -402,9 +402,7 @@ func (o *obtainer) ObtainFromCA(input ObtainInput) error {
 		var certificates *certificate.Resource
 		var err error
 
-		if input.CSR == nil {
-			certificates, err = newCASignedCertFromInput(input)
-		}
+		certificates, err = newCASignedCertFromInput(input)
 		output := &ObtainOutput{
 			Certificates: certificates,
 			IssuerInfo:   utils.NewCAIssuerInfo(input.IssuerKey),
@@ -513,7 +511,13 @@ func DecodeCertificate(tlsCrt []byte) (*x509.Certificate, error) {
 // newCASignedCertFromInput returns a new Certificate signed by a CA.
 // An x509.CertificateRequest is created from scratch based on and ObtainInput object
 func newCASignedCertFromInput(input ObtainInput) (*certificate.Resource, error) {
-	csr, err := createCertReq(input)
+	var csr *x509.CertificateRequest
+	var err error
+	if input.CSR == nil {
+		csr, err = createCertReq(input)
+	} else {
+		csr, err = extractCertificateRequest(input.CSR)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
Creating a certificate referencing a ca issuer with a given csr creates a nil pointer exception.
Example:
```
apiVersion: cert.gardener.cloud/v1alpha1
kind: Certificate
metadata:
  name: cert-csr
  namespace: default
spec:
  csr: ......
  issuerRef:
    name: some-ca-issuer
```


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Creating certificates with a given csr referencing a ca issuer do not throw a nil pointer exception anymore 
```
