### PR TITLE
Refactoring: introduce issuer key interface to simplify rewrite

### DIFF
--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -43,7 +43,7 @@ type ObtainInput struct {
 	// DNSSettings are the settings for the DNSController.
 	DNSSettings *DNSControllerSettings
 	// IssuerKey is a cluster-aware key of the issuer to use.
-	IssuerKey utils.IssuerKey
+	IssuerKey utils.IssuerKeyItf
 	// CommonName is the CN.
 	CommonName *string
 	// DNSNames are optional domain names.

--- a/pkg/cert/legobridge/delegatingprovider.go
+++ b/pkg/cert/legobridge/delegatingprovider.go
@@ -45,7 +45,7 @@ func newDelegatingProvider(
 	settings DNSControllerSettings,
 	certificateName resources.ObjectName,
 	targetClass string,
-	issuerKey utils.IssuerKey,
+	issuerKey utils.IssuerKeyItf,
 ) (ProviderWithCount, error) {
 	n := atomic.AddUint32(&serial, 1)
 	var internalPrvdr internalProvider
@@ -68,7 +68,7 @@ func newDelegatingProvider(
 type delegatingProvider struct {
 	logger      logger.LogContext
 	settings    DNSControllerSettings
-	issuerKey   utils.IssuerKey
+	issuerKey   utils.IssuerKeyItf
 	count       int32
 	presenting  map[string][]string
 	initialWait bool

--- a/pkg/cert/legobridge/reguser.go
+++ b/pkg/cert/legobridge/reguser.go
@@ -77,7 +77,7 @@ func (u *RegistrationUser) NewConfig(caDirURL string) *lego.Config {
 }
 
 // NewRegistrationUserFromEmail generates a private key and requests a new registration for the user.
-func NewRegistrationUserFromEmail(issuerKey utils.IssuerKey,
+func NewRegistrationUserFromEmail(issuerKey utils.IssuerKeyItf,
 	email string, caDirURL string, secretData map[string][]byte, eabKeyID, eabHmacKey string) (*RegistrationUser, error) {
 	privateKey, err := ExtractOrGeneratePrivateKey(secretData)
 	if err != nil {
@@ -105,7 +105,7 @@ func ExtractOrGeneratePrivateKey(secretData map[string][]byte) (crypto.PrivateKe
 }
 
 // NewRegistrationUserFromEmailAndPrivateKey requests a user registration.
-func NewRegistrationUserFromEmailAndPrivateKey(issuerKey utils.IssuerKey,
+func NewRegistrationUserFromEmailAndPrivateKey(issuerKey utils.IssuerKeyItf,
 	email string, caDirURL string, privateKey crypto.PrivateKey, eabKid, eabHmacKey string) (*RegistrationUser, error) {
 	user := &RegistrationUser{email: email, key: privateKey, caDirURL: caDirURL, eabKeyID: eabKid, eabHmacKey: eabHmacKey}
 	config := user.NewConfig(caDirURL)
@@ -155,7 +155,7 @@ func (u *RegistrationUser) RawRegistration() ([]byte, error) {
 }
 
 // RegistrationUserFromSecretData restores a RegistrationUser from a secret data map.
-func RegistrationUserFromSecretData(issuerKey utils.IssuerKey,
+func RegistrationUserFromSecretData(issuerKey utils.IssuerKeyItf,
 	email, caDirURL string, registrationRaw []byte, data map[string][]byte, eabKeyID, eabHmacKey string) (*RegistrationUser, error) {
 	privkeyBytes, ok := data[KeyPrivateKey]
 	if !ok {

--- a/pkg/cert/metrics/metrics.go
+++ b/pkg/cert/metrics/metrics.go
@@ -101,12 +101,12 @@ var (
 )
 
 // AddACMEAccountRegistration increments the ACMEAccountRegistrations counter.
-func AddACMEAccountRegistration(issuerKey utils.IssuerKey, uri, email string) {
+func AddACMEAccountRegistration(issuerKey utils.IssuerKeyItf, uri, email string) {
 	ACMEAccountRegistrations.WithLabelValues(uri, email, issuerKey.String()).Set(1)
 }
 
 // AddACMEOrder increments the ACMETotalOrders counter.
-func AddACMEOrder(issuerKey utils.IssuerKey, success bool, count int, renew bool) {
+func AddACMEOrder(issuerKey utils.IssuerKeyItf, success bool, count int, renew bool) {
 	if count > 0 {
 		name := issuerKey.String()
 		ACMETotalOrders.WithLabelValues(name, strconv.FormatBool(success), strconv.FormatInt(int64(count), 10), strconv.FormatBool(renew)).Inc()
@@ -114,23 +114,23 @@ func AddACMEOrder(issuerKey utils.IssuerKey, success bool, count int, renew bool
 }
 
 // AddActiveACMEDNSChallenge increments the ACMEActiveDNSChallenges gauge.
-func AddActiveACMEDNSChallenge(issuerKey utils.IssuerKey) {
+func AddActiveACMEDNSChallenge(issuerKey utils.IssuerKeyItf) {
 	name := issuerKey.String()
 	ACMEActiveDNSChallenges.WithLabelValues(name).Inc()
 }
 
 // RemoveActiveACMEDNSChallenge decrements the ACMEActiveDNSChallenges gauge.
-func RemoveActiveACMEDNSChallenge(issuerKey utils.IssuerKey) {
+func RemoveActiveACMEDNSChallenge(issuerKey utils.IssuerKeyItf) {
 	ACMEActiveDNSChallenges.WithLabelValues(issuerKey.String()).Dec()
 }
 
 // ReportCertEntries sets the CertEntries gauge
-func ReportCertEntries(issuertype string, issuerKey utils.IssuerKey, count int) {
+func ReportCertEntries(issuertype string, issuerKey utils.IssuerKeyItf, count int) {
 	CertEntries.WithLabelValues(issuertype, issuerKey.String()).Set(float64(count))
 }
 
 // DeleteCertEntries deletes a CertEntries gauge entry.
-func DeleteCertEntries(issuertype string, issuerKey utils.IssuerKey) {
+func DeleteCertEntries(issuertype string, issuerKey utils.IssuerKeyItf) {
 	CertEntries.DeleteLabelValues(issuertype, issuerKey.String())
 }
 

--- a/pkg/cert/utils/issuerinfo.go
+++ b/pkg/cert/utils/issuerinfo.go
@@ -15,22 +15,22 @@ const (
 
 // IssuerInfo provides name and type of an issuer
 type IssuerInfo struct {
-	key        IssuerKey
+	key        IssuerKeyItf
 	issuertype string
 }
 
 // NewACMEIssuerInfo creates info for an ACME issuer
-func NewACMEIssuerInfo(key IssuerKey) IssuerInfo {
+func NewACMEIssuerInfo(key IssuerKeyItf) IssuerInfo {
 	return IssuerInfo{key: key, issuertype: IssuerTypeACME}
 }
 
 // NewCAIssuerInfo creates info for an CA issuer
-func NewCAIssuerInfo(key IssuerKey) IssuerInfo {
+func NewCAIssuerInfo(key IssuerKeyItf) IssuerInfo {
 	return IssuerInfo{key: key, issuertype: IssuerTypeCA}
 }
 
 // Key returns the issuer key
-func (i *IssuerInfo) Key() IssuerKey {
+func (i *IssuerInfo) Key() IssuerKeyItf {
 	return i.key
 }
 

--- a/pkg/cert/utils/issuerkey.go
+++ b/pkg/cert/utils/issuerkey.go
@@ -16,11 +16,20 @@ import (
 type Cluster int
 
 const (
-	// ClusterDefault is the default cluster
+	// ClusterDefault is the default cluster (= secondary)
 	ClusterDefault Cluster = iota
-	// ClusterTarget is the target cluster
+	// ClusterTarget is the target cluster (= primary)
 	ClusterTarget
 )
+
+// IssuerKeyItf abstracts IssuerKey to simplify code reuse.
+type IssuerKeyItf interface {
+	Name() string
+	Namespace() string
+	Cluster() Cluster
+	Secondary() bool
+	String() string
+}
 
 // IssuerKey provides cluster, name and namespace of an issuer
 type IssuerKey struct {
@@ -64,6 +73,11 @@ func (k IssuerKey) NamespaceOrDefault(def string) string {
 // Cluster returns the issuer cluster
 func (k IssuerKey) Cluster() Cluster {
 	return k.cluster
+}
+
+// Secondary returns true if it is a provided issuer from the default cluster ("secondary" cluster in the new wording).
+func (k IssuerKey) Secondary() bool {
+	return k.cluster == ClusterDefault
 }
 
 // ClusterName returns the cluster name


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactoring: introduce issuer key interface to simplify rewrite without controller-manager-library.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Refactoring: introduce issuer key interface
```
