### PR TITLE
Replace registry image repository

### DIFF
--- a/hack/kind/registry/base/registry.yaml
+++ b/hack/kind/registry/base/registry.yaml
@@ -12,7 +12,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: eu.gcr.io/gardener-project/3rd/registry:2.8.3
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:2.8.3
         imagePullPolicy: IfNotPresent
         ports:
         - name: registry


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace registry image repository, as repo `eu.gcr.io/gardener-project` will disappear soon.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
