### PR TITLE
Istio gateways: Allow to specify namespace for TLS secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ metadata:
     #cert.gardener.cloud/preferred-chain: "chain name"            # optional to specify preferred-chain (value is the Subject Common Name of the root issuer)
     #cert.gardener.cloud/private-key-algorithm: ECDSA             # optional to specify algorithm for private key, allowed values are 'RSA' or 'ECDSA'
     #cert.gardener.cloud/private-key-size: "384"                  # optional to specify size of private key, allowed values for RSA are "2048", "3072", "4096" and for ECDSA "256" and "384"
+    #cert.gardener.cloud/secret-namespace: "my-namespace"         # optional to specify the namespace where the certificate secret should be created
     # annotations needed when using DNSRecords
     #cert.gardener.cloud/dnsrecord-provider-type: aws-route53
     #cert.gardener.cloud/dnsrecord-secret-ref: myns/mysecret
@@ -607,6 +608,9 @@ If you want to share a certificate between multiple services and ingresses, usin
 ```
 This will create or reuse a certificate for `*.demo.mydomain.com`. An existing certificate is automatically reused,
 if it has exactly the same common name and DNS names.
+
+The annotation `cert.gardener.cloud/secret-namespace` can be used to change the namespace, the TLS secret is created in.
+By default, it is created in the same namespace as the service. 
 
 ## Demo quick start
 
@@ -702,6 +706,7 @@ metadata:
     #cert.gardener.cloud/preferred-chain: "chain name"            # optional to specify preferred-chain (value is the Subject Common Name of the root issuer)
     #cert.gardener.cloud/private-key-algorithm: ECDSA             # optional to specify algorithm for private key, allowed values are 'RSA' or 'ECDSA'
     #cert.gardener.cloud/private-key-size: "384"                  # optional to specify size of private key, allowed values for RSA are "2048", "3072", "4096" and for ECDSA "256" and "384"
+    #cert.gardener.cloud/secret-namespace: "istio-system"         # optional to specify the namespace where the certificate secret should be created
     # annotations needed when using DNSRecords
     #cert.gardener.cloud/dnsrecord-provider-type: aws-route53
     #cert.gardener.cloud/dnsrecord-secret-ref: myns/mysecret
@@ -735,6 +740,9 @@ spec:
 
 In this case, only a `Certificate` resource would be created with domain name `*.example2.com`, as the first server item
 specifies no `tls.credentialName` field.
+
+The annotation `cert.gardener.cloud/secret-namespace` can be used to change the namespace, the TLS secret is created in.
+By default, it is created in the same namespace as the gateway object.
 
 See the [Istio tutorial](docs/usage/tutorials/istio-gateways.md) for a more detailed example.
 

--- a/docs/usage/tutorials/istio-gateways.md
+++ b/docs/usage/tutorials/istio-gateways.md
@@ -52,8 +52,9 @@ metadata:
   name: httpbin-gateway
   namespace: istio-system
   annotations:
-    #cert.gardener.cloud/dnsnames: "*.example.com" # alternative if you want to control the dns names explicitly.
     cert.gardener.cloud/purpose: managed
+    #cert.gardener.cloud/dnsnames: "*.example.com"                # alternative if you want to control the dns names explicitly.
+    #cert.gardener.cloud/secret-namespace: "istio-system"         # optional to specify the namespace where the certificate secret should be created
 spec:
   selector:
     istio: ingressgateway # use Istio default gateway implementation

--- a/examples/40-gateway-istio.yaml
+++ b/examples/40-gateway-istio.yaml
@@ -11,6 +11,7 @@ metadata:
     #cert.gardener.cloud/preferred-chain: "chain name"            # optional to specify preferred-chain (value is the Subject Common Name of the root issuer)
     #cert.gardener.cloud/private-key-algorithm: ECDSA             # optional to specify algorithm for private key, allowed values are 'RSA' or 'ECDSA'
     #cert.gardener.cloud/private-key-size: "384"                  # optional to specify size of private key, allowed values for RSA are "2048", "3072", "4096" and for ECDSA "256" and "384"
+    #cert.gardener.cloud/secret-namespace: "istio-system"         # optional to specify the namespace where the certificate secret should be created
   name: my-gateway
   namespace: default
 spec:

--- a/examples/40-service-loadbalancer.yaml
+++ b/examples/40-service-loadbalancer.yaml
@@ -18,6 +18,8 @@ metadata:
     #cert.gardener.cloud/preferred-chain: "chain name"            # optional to specify preferred-chain (value is the Subject Common Name of the root issuer)
     #cert.gardener.cloud/private-key-algorithm: ECDSA             # optional to specify algorithm for private key, allowed values are 'RSA' or 'ECDSA'
     #cert.gardener.cloud/private-key-size: "384"                  # optional to specify size of private key, allowed values for RSA are "2048", "3072", "4096" and for ECDSA "256" and "384"
+    #cert.gardener.cloud/secret-namespace: "my-namespace"         # optional to specify the namespace where the certificate secret should be created
+
     # annotations needed when using DNSRecords
     #cert.gardener.cloud/dnsrecord-provider-type: aws-route53
     #cert.gardener.cloud/dnsrecord-secret-ref: myns/mysecret

--- a/pkg/cert/source/controller.go
+++ b/pkg/cert/source/controller.go
@@ -31,6 +31,8 @@ const (
 	AnnotForwardOwnerRefs = "cert.gardener.cloud/forward-owner-refs"
 	// AnnotSecretname is the annotation for the secret name
 	AnnotSecretname = "cert.gardener.cloud/secretname" // #nosec G101 -- this is no credential
+	// AnnotSecretNamespace is the annotation for the TLS secret namespace (only used for Istio Gateways source resources)
+	AnnotSecretNamespace = "cert.gardener.cloud/secret-namespace" // #nosec G101 -- this is no credential
 	// AnnotIssuer is the annotation for the issuer name
 	AnnotIssuer = "cert.gardener.cloud/issuer"
 	// AnnotCommonName is the annotation for explicitly specifying the common name

--- a/pkg/cert/source/defaults.go
+++ b/pkg/cert/source/defaults.go
@@ -14,6 +14,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
@@ -68,10 +69,7 @@ func (f *EventFeedback) Succeeded() {
 func (f *EventFeedback) event(info *CertInfo, msg string, warning ...bool) {
 	channel := ""
 	if info != nil {
-		channel = info.SecretName
-		if info.SecretNamespace != nil {
-			channel = *info.SecretNamespace + "/" + info.SecretName
-		}
+		channel = info.SecretName.String()
 	}
 	if msg != f.events[channel] {
 		key := f.source.ClusterKey()
@@ -153,7 +151,7 @@ func (s *DefaultCertSource) GetEvents(key resources.ClusterObjectKey) map[string
 
 // NewCertsInfo creates a CertsInfo
 func NewCertsInfo() *CertsInfo {
-	return &CertsInfo{Certs: map[string]CertInfo{}}
+	return &CertsInfo{Certs: map[types.NamespacedName]CertInfo{}}
 }
 
 // CreateCertFeedback creates an event feedback for the given object.

--- a/pkg/cert/source/interface.go
+++ b/pkg/cert/source/interface.go
@@ -9,6 +9,7 @@ package source
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
@@ -20,8 +21,7 @@ import (
 
 // CertInfo contains basic certificate data.
 type CertInfo struct {
-	SecretNamespace     *string
-	SecretName          string
+	SecretName          types.NamespacedName
 	Domains             []string
 	IssuerName          *string
 	FollowCNAME         bool
@@ -34,7 +34,7 @@ type CertInfo struct {
 
 // CertsInfo contains a map of CertInfo.
 type CertsInfo struct {
-	Certs map[string]CertInfo
+	Certs map[types.NamespacedName]CertInfo
 }
 
 // CertFeedback is an interface for reporting certificate status.
@@ -65,7 +65,7 @@ type CertSourceType interface {
 }
 
 // CertTargetExtractor is type for extractor.
-type CertTargetExtractor func(logger logger.LogContext, objData resources.ObjectData) (string, error)
+type CertTargetExtractor func(logger logger.LogContext, objData resources.ObjectData) (types.NamespacedName, error)
 
 // CertSourceCreator is type for creator.
 type CertSourceCreator func(controller.Interface) (CertSource, error)
@@ -84,11 +84,11 @@ type CertState struct {
 
 // CertCurrentState contains the current state.
 type CertCurrentState struct {
-	CertStates map[string]*CertState
+	CertStates map[types.NamespacedName]*CertState
 }
 
-// ContainsSecretName returns true if name is in map.
-func (s *CertCurrentState) ContainsSecretName(name string) bool {
+// ContainsSecretName returns true if secret name is in map.
+func (s *CertCurrentState) ContainsSecretName(name types.NamespacedName) bool {
 	_, ok := s.CertStates[name]
 	return ok
 }

--- a/pkg/controller/source/gateways/istio/handler.go
+++ b/pkg/controller/source/gateways/istio/handler.go
@@ -71,13 +71,19 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 	return ctrlsource.GetCertsInfoByCollector(logger, objData, func(objData resources.ObjectData) ([]*ctrlsource.TLSData, error) {
 		var array []*ctrlsource.TLSData
 
+		var secretNamespace *string
+		if v := objData.GetAnnotations()[source.AnnotSecretNamespace]; v != "" {
+			secretNamespace = &v
+		}
+
 		switch data := objData.(type) {
 		case *istionetworkingv1.Gateway:
 			for _, server := range data.Spec.Servers {
 				if server.Tls != nil && server.Tls.CredentialName != "" {
 					array = append(array, &ctrlsource.TLSData{
-						SecretName: server.Tls.CredentialName,
-						Hosts:      parsedHosts(server.Hosts),
+						SecretName:      server.Tls.CredentialName,
+						SecretNamespace: secretNamespace,
+						Hosts:           parsedHosts(server.Hosts),
 					})
 				}
 			}
@@ -85,8 +91,9 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 			for _, server := range data.Spec.Servers {
 				if server.Tls != nil && server.Tls.CredentialName != "" {
 					array = append(array, &ctrlsource.TLSData{
-						SecretName: server.Tls.CredentialName,
-						Hosts:      parsedHosts(server.Hosts),
+						SecretName:      server.Tls.CredentialName,
+						SecretNamespace: secretNamespace,
+						Hosts:           parsedHosts(server.Hosts),
 					})
 				}
 			}
@@ -94,8 +101,9 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 			for _, server := range data.Spec.Servers {
 				if server.Tls != nil && server.Tls.CredentialName != "" {
 					array = append(array, &ctrlsource.TLSData{
-						SecretName: server.Tls.CredentialName,
-						Hosts:      parsedHosts(server.Hosts),
+						SecretName:      server.Tls.CredentialName,
+						SecretNamespace: secretNamespace,
+						Hosts:           parsedHosts(server.Hosts),
 					})
 				}
 			}

--- a/pkg/controller/source/helper.go
+++ b/pkg/controller/source/helper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gardener/cert-management/pkg/cert/source"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -89,13 +90,12 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 		} else {
 			domains = mergeCommonName(cn, tls.Hosts)
 		}
-		key := tls.SecretName
+		secretName := types.NamespacedName{Name: tls.SecretName, Namespace: objData.GetNamespace()}
 		if tls.SecretNamespace != nil {
-			key = *tls.SecretNamespace + "/" + tls.SecretName
+			secretName.Namespace = *tls.SecretNamespace
 		}
-		info.Certs[key] = source.CertInfo{
-			SecretNamespace:     tls.SecretNamespace,
-			SecretName:          tls.SecretName,
+		info.Certs[secretName] = source.CertInfo{
+			SecretName:          secretName,
 			Domains:             domains,
 			IssuerName:          issuer,
 			FollowCNAME:         followCNAME,


### PR DESCRIPTION
**What this PR does / why we need it**:
Istio expects the TLS secret in the namespace of the ingress-gateway POD.
If a `Gateway` resource should be stored in a different namespace, the managed TLS secret will be created in the same namespace. With the added annotation `cert.gardener.cloud/secret-namespace`, it is possible to specify a different namespace. This annotation is only available for Istio `Gateway` resources and `Services` of type `LoadBalancer`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Istio gateways: Allow to specify namespace for TLS secret by annotation `cert.gardener.cloud/secret-namespace`.
```
