### PR TITLE
chore: Use curl instead of wget

### DIFF
--- a/hack/kind/dns-controller-manager/dns-controller-manager-up.sh
+++ b/hack/kind/dns-controller-manager/dns-controller-manager-up.sh
@@ -20,7 +20,7 @@ download_external_dns_management_helm_charts()
     return
   fi
 
-  wget -qO- https://github.com/gardener/external-dns-management/archive/refs/tags/$VERSION.tar.gz | tar xvz -C ${SOURCE_PATH}/dev external-dns-management-${VERSION#v}/charts/external-dns-management
+  curl -sL "https://github.com/gardener/external-dns-management/archive/refs/tags/$VERSION.tar.gz" | tar xvz -C ${SOURCE_PATH}/dev external-dns-management-${VERSION#v}/charts/external-dns-management
 }
 
 install_dns_controller_manager()


### PR DESCRIPTION
**What this PR does / why we need it**:

I ran `make kind-up` which failed for me at:
```shell
hack/kind/dns-controller-manager/dns-controller-manager-up.sh: line 23: wget: command not found
```

Of course, it'd be easy to install `wget` but as `curl` is used everywhere else in the project and can serve the same purpose it could be a quick fix.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:

```other operator
NONE
```
