### PR TITLE
chore: Add /kind to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,16 @@
+**How to categorize this PR?**
+<!--
+Please select a kind for this pull request. This helps the community categorizing it.
+Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
+If multiple identifiers make sense you can also state the command multiple times, e.g.
+  /kind api-change
+  /kind cleanup
+  ...
+
+"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+-->
+/kind TODO
+
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

It extends the PR template to include a section for categorizing PRs using the `/kind` command.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

I noticed that you added missing `kind/*` labels to my PRs twice, so I figured having the reminder in the PR template would make sense. It's copied from https://github.com/gardener/gardener/blob/master/.github/pull_request_template.md?plain=1 and left out the `/area` categorization.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
