### PR TITLE
chore: Improve Renovate configuration for controller-runtime

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,23 @@
   ],
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    // Analog to: https://github.com/gardener/gardener/blob/bc9877cb5aaf725a569a973a77d5cd3545ef1590/.github/renovate.json5#L171-L188
+    {
+      "description":  "Ask for manual approval to create PRs for minor and major updates of dependencies which most likely require manual adaptations of the code.",
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
+      "dependencyDashboardApproval": true
+    },
+    // Analog to: https://github.com/gardener/gardener/blob/bc9877cb5aaf725a569a973a77d5cd3545ef1590/.github/renovate.json5#L332-L341
+    {
+      "description": "Ignore dependency updates from sigs.k8s.io/controller-runtime/tools/setup-envtest because it should be in sync with controller-runtime.",
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["sigs.k8s.io/controller-runtime/tools/setup-envtest" ],
+      "enabled": false
+    }
+  ],
   "ignoreDeps": [
     "github.com/Masterminds/semver/v3",
     "github.com/ahmetb/gen-crd-api-reference-docs",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

We usually close Renovate's pull requests for updating the [`controller-runtime/setup-envtest`](https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest) digest:
https://github.com/gardener/cert-management/pulls?q=sort%3Aupdated-desc+is%3Apr+%22sigs.k8s.io%2Fcontroller-runtime%2Ftools%2Fsetup-envtest%22+

In the [gardener/gardener](https://github.com/gardener/gardener) repository Renovate is configured to:
* ask for manual approval when it comes to major and minor updates of the `controller-runtime`
* ignore updates for the `setup-envtest` digest as it should be kept in sync (i.e. compatible) with the version of `controller-runtime` being used ([ref](https://github.com/gardener/gardener/pull/9806))

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
