### PR TITLE
chore: Reuse format script from Gardener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ add-license-headers: $(GO_ADD_LICENSE)
 	@bash $(GARDENER_HACK_DIR)/add-license-header.sh
 
 .PHONY: format
-format:
-	@go fmt ./cmd/... ./pkg/... ./test/...
+format: $(GOIMPORTS) $(GOIMPORTSREVISER)
+	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
 .PHONY: build
 build:

--- a/cmd/cert-controller-manager/main.go
+++ b/cmd/cert-controller-manager/main.go
@@ -10,6 +10,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gardener/controller-manager-library/pkg/controllermanager"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/mappings"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -20,14 +26,6 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	"github.com/gardener/controller-manager-library/pkg/controllermanager"
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/mappings"
-	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/controller-manager-library/pkg/utils"
-
-	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 
 	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	ctrl "github.com/gardener/cert-management/pkg/controller"

--- a/pkg/cert/client/scheme.go
+++ b/pkg/cert/client/scheme.go
@@ -5,8 +5,6 @@
 package client
 
 import (
-	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-
 	dnsmanv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -20,6 +18,8 @@ import (
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 )
 
 var (

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -14,18 +14,17 @@ import (
 	"sync"
 	"time"
 
-	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/cert-management/pkg/cert/metrics"
-	"github.com/gardener/cert-management/pkg/cert/utils"
+	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/go-acme/lego/v4/certcrypto"
-	"k8s.io/utils/ptr"
-
 	"github.com/go-acme/lego/v4/certificate"
 	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/lego"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
-	"github.com/gardener/controller-manager-library/pkg/resources"
+	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/cert/metrics"
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 // TLSCAKey is the secret data key for the CA key.

--- a/pkg/cert/legobridge/certificate_test.go
+++ b/pkg/cert/legobridge/certificate_test.go
@@ -7,12 +7,12 @@
 package legobridge
 
 import (
-	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-
 	"github.com/go-acme/lego/v4/certcrypto"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+
+	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 )
 
 var _ = DescribeTable("KeyType conversion",

--- a/pkg/cert/legobridge/delegatingprovider.go
+++ b/pkg/cert/legobridge/delegatingprovider.go
@@ -11,16 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v4/challenge/dns01"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/gardener/cert-management/pkg/cert/metrics"
 	"github.com/gardener/cert-management/pkg/cert/utils"
-
-	"github.com/go-acme/lego/v4/challenge"
-	"github.com/go-acme/lego/v4/challenge/dns01"
-
-	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/controller-manager-library/pkg/resources"
 )
 
 // ProviderWithCount is an extended Provider interface.

--- a/pkg/cert/legobridge/dnscontrollerprovider.go
+++ b/pkg/cert/legobridge/dnscontrollerprovider.go
@@ -11,13 +11,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/cert-management/pkg/cert/source"
-	"k8s.io/utils/ptr"
-
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/cert-management/pkg/cert/source"
 )
 
 func newDNSControllerProvider(settings DNSControllerSettings, targetClass string) (internalProvider, error) {

--- a/pkg/cert/legobridge/dnsrecordprovider.go
+++ b/pkg/cert/legobridge/dnsrecordprovider.go
@@ -11,15 +11,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/cert-management/pkg/cert/source"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"k8s.io/utils/ptr"
-
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/external-dns-management/pkg/dns"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/cert-management/pkg/cert/source"
 )
 
 func newDNSRecordProvider(settings DNSControllerSettings) (internalProvider, error) {

--- a/pkg/cert/legobridge/keystores.go
+++ b/pkg/cert/legobridge/keystores.go
@@ -14,11 +14,12 @@ import (
 	"time"
 
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
-	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	jks "github.com/pavlo-v-chernykh/keystore-go/v4"
 	corev1 "k8s.io/api/core/v1"
 	pkcs12 "software.sslmate.com/src/go-pkcs12"
+
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 )
 
 const (

--- a/pkg/cert/legobridge/reguser.go
+++ b/pkg/cert/legobridge/reguser.go
@@ -14,11 +14,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gardener/cert-management/pkg/cert/metrics"
-	"github.com/gardener/cert-management/pkg/cert/utils"
-
 	"github.com/go-acme/lego/v4/lego"
 	"github.com/go-acme/lego/v4/registration"
+
+	"github.com/gardener/cert-management/pkg/cert/metrics"
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 const (

--- a/pkg/cert/metrics/metrics.go
+++ b/pkg/cert/metrics/metrics.go
@@ -9,10 +9,11 @@ package metrics
 import (
 	"strconv"
 
-	"github.com/gardener/cert-management/pkg/cert/utils"
 	"github.com/gardener/controller-manager-library/pkg/server"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 func init() {

--- a/pkg/cert/source/defaults.go
+++ b/pkg/cert/source/defaults.go
@@ -12,15 +12,15 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
-	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/controller-manager-library/pkg/resources"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/cert/source/interface.go
+++ b/pkg/cert/source/interface.go
@@ -7,14 +7,13 @@
 package source
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 )

--- a/pkg/cert/source/reconciler.go
+++ b/pkg/cert/source/reconciler.go
@@ -12,18 +12,17 @@ import (
 	"strings"
 	"time"
 
-	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/abstract"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	certutils "github.com/gardener/cert-management/pkg/cert/utils"

--- a/pkg/cert/source/slaves.go
+++ b/pkg/cert/source/slaves.go
@@ -7,11 +7,10 @@
 package source
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 // SlaveReconcilerType creates a slaveReconciler.

--- a/pkg/controller/issuer/acme/handler.go
+++ b/pkg/controller/issuer/acme/handler.go
@@ -9,11 +9,10 @@ package acme
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/legobridge"

--- a/pkg/controller/issuer/ca/handler.go
+++ b/pkg/controller/issuer/ca/handler.go
@@ -9,11 +9,10 @@ package ca
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/legobridge"

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -15,14 +15,6 @@ import (
 	"strings"
 	"time"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/go-acme/lego/v4/certificate"
-	corev1 "k8s.io/api/core/v1"
-	apierrrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
@@ -31,6 +23,13 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	cmlutils "github.com/gardener/controller-manager-library/pkg/utils"
 	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-acme/lego/v4/certificate"
+	corev1 "k8s.io/api/core/v1"
+	apierrrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/legobridge"

--- a/pkg/controller/issuer/core/associatedObjects.go
+++ b/pkg/controller/issuer/core/associatedObjects.go
@@ -9,8 +9,9 @@ package core
 import (
 	"sync"
 
-	"github.com/gardener/cert-management/pkg/cert/utils"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 // NewAssociatedObjects creates an AssociatedObjects

--- a/pkg/controller/issuer/core/quotas.go
+++ b/pkg/controller/issuer/core/quotas.go
@@ -9,8 +9,9 @@ package core
 import (
 	"sync"
 
-	"github.com/gardener/cert-management/pkg/cert/utils"
 	"k8s.io/client-go/util/flowcontrol"
+
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 // NewQuotas create a Quotas

--- a/pkg/controller/issuer/core/referencedSecrets.go
+++ b/pkg/controller/issuer/core/referencedSecrets.go
@@ -9,8 +9,9 @@ package core
 import (
 	"sync"
 
-	"github.com/gardener/cert-management/pkg/cert/utils"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 // NewReferencedSecrets create a ReferencedSecrets

--- a/pkg/controller/issuer/core/referencedSecrets_test.go
+++ b/pkg/controller/issuer/core/referencedSecrets_test.go
@@ -12,12 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gardener/cert-management/pkg/cert/utils"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 func TestRobustRemember(t *testing.T) {

--- a/pkg/controller/issuer/core/state.go
+++ b/pkg/controller/issuer/core/state.go
@@ -7,10 +7,11 @@
 package core
 
 import (
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/cert-management/pkg/cert/utils"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 type state struct {

--- a/pkg/controller/issuer/core/support.go
+++ b/pkg/controller/issuer/core/support.go
@@ -14,15 +14,14 @@ import (
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/legobridge"

--- a/pkg/controller/issuer/core/support_test.go
+++ b/pkg/controller/issuer/core/support_test.go
@@ -8,7 +8,6 @@ package core
 
 import (
 	"github.com/Masterminds/semver/v3"
-	certutils "github.com/gardener/cert-management/pkg/cert/utils"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	certutils "github.com/gardener/cert-management/pkg/cert/utils"
 )
 
 const (

--- a/pkg/controller/issuer/reconciler.go
+++ b/pkg/controller/issuer/reconciler.go
@@ -9,6 +9,10 @@ package issuer
 import (
 	"fmt"
 
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,11 +24,6 @@ import (
 	"github.com/gardener/cert-management/pkg/controller/issuer/certificate"
 	"github.com/gardener/cert-management/pkg/controller/issuer/core"
 	"github.com/gardener/cert-management/pkg/controller/issuer/revocation"
-
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
-	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/controller-manager-library/pkg/resources"
 )
 
 func newCompoundReconciler(c controller.Interface) (reconcile.Interface, error) {

--- a/pkg/controller/issuer/revocation/reconciler.go
+++ b/pkg/controller/issuer/revocation/reconciler.go
@@ -13,18 +13,17 @@ import (
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	apierrrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/errors"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	apierrrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/legobridge"

--- a/pkg/controller/source/gateways/crdwatch/controller.go
+++ b/pkg/controller/source/gateways/crdwatch/controller.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"time"
 
-	ctrl "github.com/gardener/cert-management/pkg/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	ctrl "github.com/gardener/cert-management/pkg/controller"
 )
 
 // Controller is the controller name.

--- a/pkg/controller/source/gateways/gatewayapi/controller.go
+++ b/pkg/controller/source/gateways/gatewayapi/controller.go
@@ -7,10 +7,10 @@ package gatewayapi
 import (
 	"strings"
 
-	ctrl "github.com/gardener/cert-management/pkg/controller"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 
 	"github.com/gardener/cert-management/pkg/cert/source"
+	ctrl "github.com/gardener/cert-management/pkg/controller"
 )
 
 // Group is the group of the Gateway API.

--- a/pkg/controller/source/gateways/gatewayapi/handler.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	ctrlsource "github.com/gardener/cert-management/pkg/controller/source"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
@@ -18,6 +17,7 @@ import (
 	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/gardener/cert-management/pkg/cert/source"
+	ctrlsource "github.com/gardener/cert-management/pkg/controller/source"
 )
 
 type httpRouteLister interface {

--- a/pkg/controller/source/gateways/gatewayapi/handler_test.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler_test.go
@@ -5,8 +5,6 @@
 package gatewayapi
 
 import (
-	"github.com/gardener/cert-management/pkg/cert/source"
-	ctrlsource "github.com/gardener/cert-management/pkg/controller/source"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	. "github.com/onsi/ginkgo/v2"
@@ -15,6 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/gardener/cert-management/pkg/cert/source"
+	ctrlsource "github.com/gardener/cert-management/pkg/controller/source"
 )
 
 var _ = Describe("Kubernetes Networking Gateway Handler", func() {

--- a/pkg/controller/source/gateways/istio/controller.go
+++ b/pkg/controller/source/gateways/istio/controller.go
@@ -7,12 +7,12 @@ package istio
 import (
 	"strings"
 
+	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	"github.com/gardener/cert-management/pkg/cert/source"
 	ctrl "github.com/gardener/cert-management/pkg/controller"
 	"github.com/gardener/cert-management/pkg/controller/source/ingress"
 	"github.com/gardener/cert-management/pkg/controller/source/service"
-
-	"github.com/gardener/controller-manager-library/pkg/resources"
 )
 
 var (

--- a/pkg/controller/source/gateways/istio/handler_test.go
+++ b/pkg/controller/source/gateways/istio/handler_test.go
@@ -7,8 +7,6 @@ package istio
 import (
 	"fmt"
 
-	"github.com/gardener/cert-management/pkg/cert/source"
-	ctrlsource "github.com/gardener/cert-management/pkg/controller/source"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,6 +17,9 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/gardener/cert-management/pkg/cert/source"
+	ctrlsource "github.com/gardener/cert-management/pkg/controller/source"
 )
 
 var _ = Describe("Istio Gateway Handler", func() {

--- a/pkg/controller/source/helper.go
+++ b/pkg/controller/source/helper.go
@@ -10,11 +10,12 @@ import (
 	"fmt"
 	"strconv"
 
-	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/cert-management/pkg/cert/source"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"k8s.io/apimachinery/pkg/types"
+
+	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/cert/source"
 )
 
 const (

--- a/pkg/controller/source/ingress/handler.go
+++ b/pkg/controller/source/ingress/handler.go
@@ -9,12 +9,11 @@ package ingress
 import (
 	"fmt"
 
-	networkingv1 "k8s.io/api/networking/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/gardener/cert-management/pkg/cert/source"
 	ctrlsource "github.com/gardener/cert-management/pkg/controller/source"

--- a/pkg/controller/source/service/handler.go
+++ b/pkg/controller/source/service/handler.go
@@ -9,11 +9,10 @@ package service
 import (
 	"fmt"
 
-	api "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/gardener/cert-management/pkg/cert/source"
 )

--- a/test/functional/basics.go
+++ b/test/functional/basics.go
@@ -11,15 +11,15 @@ import (
 	"crypto/x509"
 	"time"
 
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/cert-management/pkg/cert/legobridge"
-	"github.com/gardener/cert-management/test/functional/config"
-
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/cert/legobridge"
+	"github.com/gardener/cert-management/test/functional/config"
 )
 
 var basicTemplate = `

--- a/test/functional/config/utils.go
+++ b/test/functional/config/utils.go
@@ -16,9 +16,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gardener/cert-management/pkg/cert/legobridge"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/cert-management/pkg/cert/legobridge"
 )
 
 const STATE_DELETED = "~DELETED~"

--- a/test/functional/dnsrecords.go
+++ b/test/functional/dnsrecords.go
@@ -12,22 +12,22 @@ import (
 	"os"
 	"time"
 
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/cert-management/test/functional/config"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/utils"
 	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kube-openapi/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/test/functional/config"
 )
 
 var dnsrecordsTemplate = `

--- a/test/integration/controller/issuer/issuer_suite_test.go
+++ b/test/integration/controller/issuer/issuer_suite_test.go
@@ -13,11 +13,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	certclient "github.com/gardener/cert-management/pkg/cert/client"
-	ctrl "github.com/gardener/cert-management/pkg/controller"
-	_ "github.com/gardener/cert-management/pkg/controller/issuer"
-	testutils "github.com/gardener/cert-management/test/utils"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/mappings"
@@ -35,6 +30,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	certclient "github.com/gardener/cert-management/pkg/cert/client"
+	ctrl "github.com/gardener/cert-management/pkg/controller"
+	_ "github.com/gardener/cert-management/pkg/controller/issuer"
+	testutils "github.com/gardener/cert-management/test/utils"
 )
 
 func TestIssuerController(t *testing.T) {

--- a/test/integration/controller/issuer/issuer_test.go
+++ b/test/integration/controller/issuer/issuer_test.go
@@ -9,8 +9,6 @@ package issuer_test
 import (
 	"context"
 
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager"
 	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -19,6 +17,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 )
 
 var _ = Describe("Issuer controller tests", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR reuses the script [`hack/format.sh`](https://github.com/gardener/gardener/blob/master/hack/format.sh) which is part of the `gardener/gardener` repository.

All changes aside from the `Makefile` have been introduced by running `make format`.

PR #228 already uses the same approach for formatting and structuring the Go imports.
As it already conflicts with the `master` branch I'd like to introduce the formatting changes on `master` first before rebasing it.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
