### PR TITLE
feat: Introduce certificate duration

### DIFF
--- a/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
@@ -88,6 +88,15 @@ spec:
                 items:
                   type: string
                 type: array
+              duration:
+                description: |-
+                  Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                  ACME issuer may choose to ignore the requested duration, just like any other
+                  requested attribute.
+                  If unset, this defaults to 90 days (2160h).
+                  Must be greater than twice of the renewal window
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                type: string
               ensureRenewedAfter:
                 description: EnsureRenewedAfter specifies a time stamp in the past.
                   Renewing is only triggered if certificate notBefore date is before

--- a/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
+++ b/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
@@ -83,6 +83,15 @@ spec:
                 items:
                   type: string
                 type: array
+              duration:
+                description: |-
+                  Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                  ACME issuer may choose to ignore the requested duration, just like any other
+                  requested attribute.
+                  If unset, this defaults to 90 days (2160h).
+                  Must be greater than twice of the renewal window
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                type: string
               ensureRenewedAfter:
                 description: EnsureRenewedAfter specifies a time stamp in the past.
                   Renewing is only triggered if certificate notBefore date is before

--- a/pkg/apis/cert/crds/zz_generated_crds.go
+++ b/pkg/apis/cert/crds/zz_generated_crds.go
@@ -387,6 +387,15 @@ spec:
                 items:
                   type: string
                 type: array
+              duration:
+                description: |-
+                  Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                  ACME issuer may choose to ignore the requested duration, just like any other
+                  requested attribute.
+                  If unset, this defaults to 90 days (2160h).
+                  Must be greater than twice of the renewal window
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                type: string
               ensureRenewedAfter:
                 description: EnsureRenewedAfter specifies a time stamp in the past.
                   Renewing is only triggered if certificate notBefore date is before

--- a/pkg/apis/cert/v1alpha1/types.go
+++ b/pkg/apis/cert/v1alpha1/types.go
@@ -85,6 +85,14 @@ type CertificateSpec struct {
 	// Private key options. These include the key algorithm and size.
 	// +optional
 	PrivateKey *CertificatePrivateKey `json:"privateKey,omitempty"`
+	// Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+	// ACME issuer may choose to ignore the requested duration, just like any other
+	// requested attribute.
+	// If unset, this defaults to 90 days (2160h).
+	// Must be greater than twice of the renewal window
+	// Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+	// +optional
+	Duration *metav1.Duration `json:"duration,omitempty"`
 }
 
 // IssuerRef is the reference of the issuer by name.

--- a/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
@@ -453,6 +453,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(CertificatePrivateKey)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -63,6 +63,8 @@ type ObtainInput struct {
 	PreferredChain string
 	// KeyType represents the algo and size to use for the private key (only used if CSR is not set).
 	KeyType certcrypto.KeyType
+	// Duration is the lifetime of the certificate
+	Duration time.Duration
 }
 
 // DNSControllerSettings are the settings for the DNSController.

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -536,7 +536,10 @@ func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyP
 	if err != nil {
 		return nil, err
 	}
-	return issueSignedCert(csr, false, privKey, privKeyPEM, CAKeyPair, duration)
+	if duration == nil {
+		return nil, fmt.Errorf("duration must be set")
+	}
+	return issueSignedCert(csr, false, privKey, privKeyPEM, CAKeyPair, *duration)
 }
 
 // RevokeCertificate revokes a certificate

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -161,6 +161,7 @@ func obtainForDomains(client *lego.Client, domains []string, input ObtainInput) 
 		AlwaysDeactivateAuthorizations: input.AlwaysDeactivateAuthorizations,
 		PreferredChain:                 input.PreferredChain,
 		PrivateKey:                     privateKey,
+		NotAfter:                       time.Now().Add(input.Duration),
 	}
 	return client.Certificate.Obtain(request)
 }
@@ -277,6 +278,7 @@ func obtainForCSR(client *lego.Client, csr []byte, input ObtainInput) (*certific
 		Bundle:                         true,
 		AlwaysDeactivateAuthorizations: input.AlwaysDeactivateAuthorizations,
 		PreferredChain:                 input.PreferredChain,
+		NotAfter:                       time.Now().Add(input.Duration),
 	})
 }
 

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -522,12 +522,12 @@ func newCASignedCertFromInput(input ObtainInput) (*certificate.Resource, error) 
 	if err != nil {
 		return nil, err
 	}
-	return newCASignedCertFromCertReq(csr, input.CAKeyPair)
+	return newCASignedCertFromCertReq(csr, input.CAKeyPair, input.Duration)
 }
 
 // newCASignedCertFromCertReq returns a new Certificate signed by a CA based on
 // an x509.CertificateRequest and a CA key pair. A private key will be generated.
-func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyPair) (*certificate.Resource, error) {
+func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyPair, duration time.Duration) (*certificate.Resource, error) {
 	pubKeySize := pubKeySize(csr.PublicKey)
 	if pubKeySize == 0 {
 		pubKeySize = defaultKeySize(csr.PublicKeyAlgorithm)
@@ -536,7 +536,7 @@ func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyP
 	if err != nil {
 		return nil, err
 	}
-	return issueSignedCert(csr, false, privKey, privKeyPEM, CAKeyPair)
+	return issueSignedCert(csr, false, privKey, privKeyPEM, CAKeyPair, duration)
 }
 
 // RevokeCertificate revokes a certificate

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -64,7 +64,7 @@ type ObtainInput struct {
 	// KeyType represents the algo and size to use for the private key (only used if CSR is not set).
 	KeyType certcrypto.KeyType
 	// Duration is the lifetime of the certificate
-	Duration time.Duration
+	Duration *time.Duration
 }
 
 // DNSControllerSettings are the settings for the DNSController.
@@ -161,7 +161,6 @@ func obtainForDomains(client *lego.Client, domains []string, input ObtainInput) 
 		AlwaysDeactivateAuthorizations: input.AlwaysDeactivateAuthorizations,
 		PreferredChain:                 input.PreferredChain,
 		PrivateKey:                     privateKey,
-		NotAfter:                       time.Now().Add(input.Duration),
 	}
 	return client.Certificate.Obtain(request)
 }
@@ -278,7 +277,6 @@ func obtainForCSR(client *lego.Client, csr []byte, input ObtainInput) (*certific
 		Bundle:                         true,
 		AlwaysDeactivateAuthorizations: input.AlwaysDeactivateAuthorizations,
 		PreferredChain:                 input.PreferredChain,
-		NotAfter:                       time.Now().Add(input.Duration),
 	})
 }
 
@@ -529,7 +527,7 @@ func newCASignedCertFromInput(input ObtainInput) (*certificate.Resource, error) 
 
 // newCASignedCertFromCertReq returns a new Certificate signed by a CA based on
 // an x509.CertificateRequest and a CA key pair. A private key will be generated.
-func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyPair, duration time.Duration) (*certificate.Resource, error) {
+func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyPair, duration *time.Duration) (*certificate.Resource, error) {
 	pubKeySize := pubKeySize(csr.PublicKey)
 	if pubKeySize == 0 {
 		pubKeySize = defaultKeySize(csr.PublicKeyAlgorithm)

--- a/pkg/cert/legobridge/pki.go
+++ b/pkg/cert/legobridge/pki.go
@@ -62,7 +62,7 @@ const (
 )
 
 // issueSignedCert does all the Certificate Issuing.
-func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Signer, privKeyPEM []byte, signerKeyPair *TLSKeyPair, duration *time.Duration) (*certificate.Resource, error) {
+func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Signer, privKeyPEM []byte, signerKeyPair *TLSKeyPair, duration time.Duration) (*certificate.Resource, error) {
 	csrPEM, err := generateCSRPEM(csr, privKey)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func generateCSRPEM(csr *x509.CertificateRequest, privateKey crypto.Signer) ([]b
 }
 
 // generateCertFromCSR generates an x509.Certificate based on a PEM encoded CSR.
-func generateCertFromCSR(csrPEM []byte, duration *time.Duration, isCA bool) (*x509.Certificate, error) {
+func generateCertFromCSR(csrPEM []byte, duration time.Duration, isCA bool) (*x509.Certificate, error) {
 	var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
 	csr, err := extractCertificateRequest(csrPEM)
@@ -217,7 +217,7 @@ func generateCertFromCSR(csrPEM []byte, duration *time.Duration, isCA bool) (*x5
 		IsCA:                  isCA,
 		Subject:               csr.Subject,
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(*duration),
+		NotAfter:              time.Now().Add(duration),
 		KeyUsage:              ku,
 		ExtKeyUsage:           DefaultCertExtKeyUsage,
 		DNSNames:              csr.DNSNames,

--- a/pkg/cert/legobridge/pki.go
+++ b/pkg/cert/legobridge/pki.go
@@ -62,12 +62,12 @@ const (
 )
 
 // issueSignedCert does all the Certificate Issuing.
-func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Signer, privKeyPEM []byte, signerKeyPair *TLSKeyPair) (*certificate.Resource, error) {
+func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Signer, privKeyPEM []byte, signerKeyPair *TLSKeyPair, duration time.Duration) (*certificate.Resource, error) {
 	csrPEM, err := generateCSRPEM(csr, privKey)
 	if err != nil {
 		return nil, err
 	}
-	crt, err := generateCertFromCSR(csrPEM, DefaultCertDuration, isCA)
+	crt, err := generateCertFromCSR(csrPEM, duration, isCA)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cert/legobridge/pki.go
+++ b/pkg/cert/legobridge/pki.go
@@ -62,7 +62,7 @@ const (
 )
 
 // issueSignedCert does all the Certificate Issuing.
-func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Signer, privKeyPEM []byte, signerKeyPair *TLSKeyPair, duration time.Duration) (*certificate.Resource, error) {
+func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Signer, privKeyPEM []byte, signerKeyPair *TLSKeyPair, duration *time.Duration) (*certificate.Resource, error) {
 	csrPEM, err := generateCSRPEM(csr, privKey)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func generateCSRPEM(csr *x509.CertificateRequest, privateKey crypto.Signer) ([]b
 }
 
 // generateCertFromCSR generates an x509.Certificate based on a PEM encoded CSR.
-func generateCertFromCSR(csrPEM []byte, duration time.Duration, isCA bool) (*x509.Certificate, error) {
+func generateCertFromCSR(csrPEM []byte, duration *time.Duration, isCA bool) (*x509.Certificate, error) {
 	var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
 	csr, err := extractCertificateRequest(csrPEM)
@@ -217,7 +217,7 @@ func generateCertFromCSR(csrPEM []byte, duration time.Duration, isCA bool) (*x50
 		IsCA:                  isCA,
 		Subject:               csr.Subject,
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(duration),
+		NotAfter:              time.Now().Add(*duration),
 		KeyUsage:              ku,
 		ExtKeyUsage:           DefaultCertExtKeyUsage,
 		DNSNames:              csr.DNSNames,

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -643,6 +643,17 @@ func (r *certReconciler) checkDomainRangeRestriction(issuerDomains *api.DNSSelec
 	return nil
 }
 
+func (r *certReconciler) getDuration(cert *api.Certificate) (time.Duration, error) {
+	duration := legobridge.DefaultCertDuration
+	if cert.Spec.Duration != nil {
+		duration = cert.Spec.Duration.Duration
+		if duration < 2*r.renewalWindow {
+			return 0, fmt.Errorf("self signed certificate duration must be greater than %v", 2*r.renewalWindow)
+		}
+	}
+	return duration, nil
+}
+
 func (r *certReconciler) loadSecret(secretRef *corev1.SecretReference) (*corev1.Secret, error) {
 	secretObjectName := resources.NewObjectName(secretRef.Namespace, secretRef.Name)
 	secret := &corev1.Secret{}

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -669,6 +669,9 @@ func (r *certReconciler) getDuration(cert *api.Certificate) (*time.Duration, err
 }
 
 func (r *certReconciler) validateCertDuration(duration *time.Duration, caKeyPair *legobridge.TLSKeyPair) error {
+	if duration == nil {
+		return nil
+	}
 	caNotAfter := caKeyPair.Cert.NotAfter
 	now := time.Now()
 	if now.Add(*duration).After(caNotAfter) {

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -402,7 +402,10 @@ func (r *certReconciler) obtainCertificateAndPendingACME(logctx logger.LogContex
 	if err != nil {
 		return r.failed(logctx, obj, api.StateError, err)
 	}
-
+	duration, err := r.getDuration(cert)
+	if err != nil {
+		return r.failedStop(logctx, obj, api.StateError, err)
+	}
 	err = r.validateDomainsAndCsr(&cert.Spec, issuer.Spec.ACME.Domains, issuerKey)
 	if err != nil {
 		return r.failedStop(logctx, obj, api.StateError, err)
@@ -501,6 +504,7 @@ func (r *certReconciler) obtainCertificateAndPendingACME(logctx logger.LogContex
 		AlwaysDeactivateAuthorizations: r.alwaysDeactivateAuthorizations,
 		PreferredChain:                 preferredChain,
 		KeyType:                        keyType,
+		Duration:                       duration,
 	}
 
 	err = r.obtainer.Obtain(input)

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -30,6 +30,7 @@ import (
 	apierrrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/legobridge"

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -562,8 +562,7 @@ func (r *certReconciler) obtainCertificateCA(logctx logger.LogContext, obj resou
 		return r.failedStop(logctx, obj, api.StateError, err)
 	}
 	if duration == nil {
-		defaultDuration := 2 * legobridge.DefaultCertDuration
-		duration = &defaultDuration
+		duration = ptr.To(2 * legobridge.DefaultCertDuration)
 	}
 	err = r.validateCertDuration(duration, CAKeyPair)
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR cherry-picks commits from #228 and introduces the `Duration` field on the `Certificate` resource.
It allows you to specify the certificate's lifetime. Issuers, like Let's Encrypt, may ignore this field.

As a secondary goal, by extracting the changes around the duration of certificates from #228 its changeset should become smaller and focused around the introduction of the self-signed issuer.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The certificate resource can now define a duration (the lifetime of the certificate). The issuer (especially Let's Encrypt) may ignore this field.
```
