### PR TITLE
Enh/improve flaky e2e test

### DIFF
--- a/hack/kind/certman/issuer-up.sh
+++ b/hack/kind/certman/issuer-up.sh
@@ -11,6 +11,8 @@ source $(dirname ${0})/../common.sh /..
 
 kubectl apply -f ${SOURCE_PATH}/pkg/apis/cert/crds/cert.gardener.cloud_issuers.yaml
 
+kubectl wait crd issuers.cert.gardener.cloud --for=condition=NamesAccepted
+
 cat  << EOF | kubectl apply -f -
 apiVersion: cert.gardener.cloud/v1alpha1
 kind: Issuer

--- a/hack/kind/local-issuer/local-issuer-up.sh
+++ b/hack/kind/local-issuer/local-issuer-up.sh
@@ -11,6 +11,8 @@ source $(dirname ${0})/../common.sh /..
 
 kubectl apply -f ${SOURCE_PATH}/pkg/apis/cert/crds/cert.gardener.cloud_issuers.yaml
 
+kubectl wait crd issuers.cert.gardener.cloud --for=condition=NamesAccepted
+
 cat  << EOF | kubectl apply -f -
 apiVersion: cert.gardener.cloud/v1alpha1
 kind: Issuer

--- a/test/functional/config/config.go
+++ b/test/functional/config/config.go
@@ -116,7 +116,10 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, fmt.Errorf("Post processing config file %s failed: %w", filename, err)
 	}
 
-	config.Utils = CreateDefaultTestUtils()
+	config.Utils, err = CreateDefaultTestUtils()
+	if err != nil {
+		return nil, fmt.Errorf("Creating test utils failed: %w", err)
+	}
 
 	return config, nil
 }

--- a/test/functional/config/utils.go
+++ b/test/functional/config/utils.go
@@ -7,18 +7,28 @@
 package config
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
-	"strings"
 	"time"
 
-	"github.com/onsi/gomega"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	extensionsv1alpha "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/retry"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/legobridge"
 )
 
@@ -29,15 +39,39 @@ type TestUtils struct {
 	PollingPeriod time.Duration
 	Namespace     string
 	Verbose       bool
+	Client        client.Client
 }
 
-func CreateDefaultTestUtils() *TestUtils {
+func init() {
+	utils.Must(resources.Register(corev1.SchemeBuilder))
+	utils.Must(resources.Register(apiextensionsv1.SchemeBuilder))
+	utils.Must(resources.Register(v1alpha1.SchemeBuilder))
+	utils.Must(resources.Register(extensionsv1alpha.SchemeBuilder))
+	utils.Must(resources.Register(dnsapi.SchemeBuilder))
+}
+
+func CreateDefaultTestUtils() (*TestUtils, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return nil, fmt.Errorf("KUBECONFIG not set")
+	}
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("Error loading kubeconfig from %s: %v\n", kubeconfig, err)
+	}
+	c, err := client.New(restConfig, client.Options{
+		Scheme: resources.DefaultScheme(),
+	})
+	if err != nil {
+		return nil, err
+	}
 	return &TestUtils{
 		AwaitTimeout:  240 * time.Second,
 		PollingPeriod: 200 * time.Millisecond,
 		Namespace:     "default",
 		Verbose:       true,
-	}
+		Client:        c,
+	}, nil
 }
 
 func (u *TestUtils) KubectlPlain(cmdline string) (string, error) {
@@ -60,28 +94,26 @@ func (u *TestUtils) KubectlGetAllCertificatesPlain() (string, error) {
 	return output, nil
 }
 
-func (u *TestUtils) KubectlGetAllCertificates() (map[string]interface{}, error) {
-	output, err := u.runKubeCtl("get cert -o json")
-	if err != nil {
+func (u *TestUtils) GetAllCertificates(ctx context.Context) (map[string]v1alpha1.Certificate, error) {
+	list := &v1alpha1.CertificateList{}
+	if err := u.Client.List(ctx, list); err != nil {
 		return nil, err
 	}
-	return u.toItemMap(output)
+	certs := map[string]v1alpha1.Certificate{}
+	for _, item := range list.Items {
+		certs[item.Name] = item
+	}
+	return certs, nil
 }
 
-func (u *TestUtils) KubectlGetSecret(name string) (*corev1.Secret, error) {
-	output, err := u.runKubeCtl("get secret " + name + " -o json")
-	if err != nil {
-		return nil, err
-	}
+func (u *TestUtils) GetSecret(name string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
-	if err = json.Unmarshal([]byte(output), secret); err != nil {
-		return nil, err
-	}
-	return secret, nil
+	err := u.Client.Get(context.Background(), client.ObjectKey{Namespace: u.Namespace, Name: name}, secret)
+	return secret, err
 }
 
 func (u *TestUtils) CheckCertificatePrivateKey(secretName string, algorithm x509.PublicKeyAlgorithm, keySize int) error {
-	secret, err := u.KubectlGetSecret(secretName)
+	secret, err := u.GetSecret(secretName)
 	if err != nil {
 		return err
 	}
@@ -108,27 +140,6 @@ func (u *TestUtils) CheckCertificatePrivateKey(secretName string, algorithm x509
 		return fmt.Errorf("unknown public key")
 	}
 	return nil
-}
-
-func (u *TestUtils) toItemMap(output string) (map[string]interface{}, error) {
-	untyped := map[string]interface{}{}
-	err := json.Unmarshal([]byte(output), &untyped)
-	if err != nil {
-		return nil, err
-	}
-
-	if untyped["kind"] != "List" {
-		return nil, fmt.Errorf("Result is not a list")
-	}
-
-	itemMap := map[string]interface{}{}
-	items := untyped["items"].([]interface{})
-	for _, rawItem := range items {
-		item := rawItem.(map[string]interface{})
-		name := item["metadata"].(map[string]interface{})["name"].(string)
-		itemMap[name] = item
-	}
-	return itemMap, err
 }
 
 func (u *TestUtils) KubectlApply(filename string) error {
@@ -163,97 +174,100 @@ func (u *TestUtils) runCmd(cmdline string) (string, error) {
 	return string(out), nil
 }
 
-func (u *TestUtils) AwaitIssuerReady(names ...string) error {
-	return u.AwaitState("issuer", "Ready", names...)
+func (u *TestUtils) WaitUntilIssuerReady(ctx context.Context, names ...string) error {
+	return u.WaitUntilIssuerState(ctx, "Ready", names...)
 }
 
-func (u *TestUtils) AwaitIssuerDeleted(names ...string) error {
-	return u.AwaitState("issuer", STATE_DELETED, names...)
+func (u *TestUtils) WaitUntilIssuerDeleted(ctx context.Context, names ...string) error {
+	return u.WaitUntilIssuerState(ctx, STATE_DELETED, names...)
 }
 
-func (u *TestUtils) AwaitCertReady(names ...string) error {
-	return u.AwaitState("cert", "Ready", names...)
+func (u *TestUtils) WaitUntilCertReady(ctx context.Context, names ...string) error {
+	return u.WaitUntilCertState(ctx, "Ready", names...)
 }
 
-func (u *TestUtils) AwaitCertError(names ...string) error {
-	return u.AwaitState("cert", "Error", names...)
+func (u *TestUtils) WaitUntilCertError(ctx context.Context, names ...string) error {
+	return u.WaitUntilCertState(ctx, "Error", names...)
 }
 
-func (u *TestUtils) AwaitCertDeleted(names ...string) error {
-	return u.AwaitState("cert", STATE_DELETED, names...)
+func (u *TestUtils) WaitUntilCertDeleted(ctx context.Context, names ...string) error {
+	return u.WaitUntilCertState(ctx, STATE_DELETED, names...)
 }
 
-func (u *TestUtils) AwaitCertRevoked(names ...string) error {
-	return u.AwaitState("cert", "Revoked", names...)
+func (u *TestUtils) WaitUntilCertRevoked(ctx context.Context, names ...string) error {
+	return u.WaitUntilCertState(ctx, "Revoked", names...)
 }
 
-func (u *TestUtils) AwaitCertRevocationApplied(name string) error {
-	return u.AwaitState("certrevoke", "Applied", name)
+func (u *TestUtils) WaitUntilCertRevocationApplied(ctx context.Context, name string) error {
+	return u.WaitUntilCertificateRevocationState(ctx, "Applied", name)
 }
 
-func (u *TestUtils) AwaitState(resourceName, expectedState string, names ...string) error {
-	msg := fmt.Sprintf("%s not %s: %v", resourceName, expectedState, names)
-	return u.Await(msg, func() (bool, error) {
-		output, err := u.runKubeCtl("get " + resourceName + " \"-o=jsonpath={range .items[*]}{.metadata.name}={.status.state}{'\\n'}{end}\"")
-		if err != nil {
-			return false, err
+// WaitUntilCertState takes names of Certificates and waits for them to get ready with a timeout of 15 seconds.
+func (u *TestUtils) WaitUntilCertState(ctx context.Context, expectedState string, names ...string) error {
+	return waitUntil(ctx, u.Client, &v1alpha1.Certificate{}, func(obj *v1alpha1.Certificate) (bool, error) {
+		if obj.Status.State != expectedState {
+			return retry.MinorError(fmt.Errorf("Certificate %s has state %s != %s", obj.Name, obj.Status.State, expectedState))
 		}
+		return retry.Ok()
 
-		states := map[string]string{}
-		lines := strings.Split(output, "\n")
-		for _, line := range lines {
-			cols := strings.Split(line, "=")
-			if len(cols) == 2 {
-				states[cols[0]] = cols[1]
-			}
+	}, u.AwaitTimeout, expectedState == STATE_DELETED, u.Namespace, names...)
+}
+
+// WaitUntilCertificateRevocationState takes names of CertificateRevocations and waits for them to get ready with a timeout of 15 seconds.
+func (u *TestUtils) WaitUntilCertificateRevocationState(ctx context.Context, expectedState string, names ...string) error {
+	return waitUntil(ctx, u.Client, &v1alpha1.CertificateRevocation{}, func(obj *v1alpha1.CertificateRevocation) (bool, error) {
+		if obj.Status.State != expectedState {
+			return retry.MinorError(fmt.Errorf("CertificateRevocation %s has state %s != %s", obj.Name, obj.Status.State, expectedState))
 		}
-		for _, name := range names {
-			if expectedState == STATE_DELETED {
-				if _, ok := states[name]; ok {
-					return false, nil
+		return retry.Ok()
+
+	}, u.AwaitTimeout, expectedState == STATE_DELETED, u.Namespace, names...)
+}
+
+// WaitUntilIssuerState takes names of Issuer and waits for them to get ready with a timeout of 15 seconds.
+func (u *TestUtils) WaitUntilIssuerState(ctx context.Context, expectedState string, names ...string) error {
+	return waitUntil(ctx, u.Client, &v1alpha1.Issuer{}, func(obj *v1alpha1.Issuer) (bool, error) {
+		if obj.Status.State != expectedState {
+			return retry.MinorError(fmt.Errorf("Issuer %s has state %s != %s", obj.Name, obj.Status.State, expectedState))
+		}
+		return retry.Ok()
+
+	}, u.AwaitTimeout, expectedState == STATE_DELETED, u.Namespace, names...)
+}
+
+func (u *TestUtils) WaitUntilCRDsReady(ctx context.Context, crds ...string) error {
+	return waitUntil(ctx, u.Client, &apiextensionsv1.CustomResourceDefinition{}, func(obj *apiextensionsv1.CustomResourceDefinition) (bool, error) {
+		if err := health.CheckCustomResourceDefinition(obj); err != nil {
+			return retry.MinorError(err)
+		}
+		return retry.Ok()
+	}, u.AwaitTimeout, false, u.Namespace, crds...)
+}
+
+// waitUntil takes names of objects and waits for them that the check method succeeds.
+func waitUntil[T client.Object](ctx context.Context, c client.Client, t T, check func(t T) (bool, error), timeout time.Duration, ignoreNotFound bool, namespace string, names ...string) error {
+	var fns []flow.TaskFn
+	for _, name := range names {
+		fns = append(fns, func(ctx context.Context) error {
+			timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			return retry.Until(timeoutCtx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
+				obj := t.DeepCopyObject().(T)
+
+				if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+					if client.IgnoreNotFound(err) == nil {
+						if ignoreNotFound {
+							return retry.Ok()
+						}
+						return retry.MinorError(err)
+					}
+					return retry.SevereError(err)
 				}
-			} else if states[name] != expectedState {
-				return false, nil
-			}
-		}
-		return true, nil
-	})
-}
 
-type CheckFunc func() (bool, error)
-
-func (u *TestUtils) Await(msg string, check CheckFunc) error {
-	return u.AwaitWithTimeout(msg, check, u.AwaitTimeout)
-}
-
-func (u *TestUtils) AwaitWithTimeout(msg string, check CheckFunc, timeout time.Duration) error {
-	var err error
-	var ok bool
-
-	limit := time.Now().Add(timeout)
-	for time.Now().Before(limit) {
-		ok, err = check()
-		if ok {
-			return nil
-		}
-		time.Sleep(u.PollingPeriod)
+				return check(obj)
+			})
+		})
 	}
-	if err != nil {
-		return fmt.Errorf("Timeout during check %s with error: %w", msg, err)
-	}
-	return fmt.Errorf("Timeout during check  %s", msg)
-}
-
-func (u *TestUtils) AwaitKubectlGetCRDs(crds ...string) error {
-	var err error
-	for _, crd := range crds {
-		gomega.Eventually(func() error {
-			_, err = u.runKubeCtl("get crd " + crd)
-			return err
-		}, u.AwaitTimeout, u.PollingPeriod).Should(gomega.BeNil())
-		if err != nil {
-			return err
-		}
-	}
-	return err
+	return flow.Parallel(fns...)(ctx)
 }

--- a/test/functional/config/utils.go
+++ b/test/functional/config/utils.go
@@ -33,7 +33,7 @@ type TestUtils struct {
 
 func CreateDefaultTestUtils() *TestUtils {
 	return &TestUtils{
-		AwaitTimeout:  180 * time.Second,
+		AwaitTimeout:  240 * time.Second,
 		PollingPeriod: 200 * time.Millisecond,
 		Namespace:     "default",
 		Verbose:       true,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind flake
/kind cleanup

**What this PR does / why we need it**:
- Address flaky e2e-kind test.
- Refactoring e2e test to get closer to gardener patterns

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
