### PR TITLE
Fix flaky check for keystore data in secret

### DIFF
--- a/test/functional/basics.go
+++ b/test/functional/basics.go
@@ -415,15 +415,15 @@ func functestbasics(cfg *config.Config, iss *config.IssuerConfig) {
 				err = u.KubectlApply(manifestFilename)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				time.Sleep(3 * time.Second) // wait for reconciliation
-
-				secret, err = u.GetSecret("cert3-secret")
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(secret.Data).Should(HaveLen(7))
-				Expect(secret.Data[legobridge.JKSTruststoreKey]).ShouldNot(BeNil())
-				Expect(secret.Data[legobridge.JKSSecretKey]).ShouldNot(BeNil())
-				Expect(secret.Data[legobridge.PKCS12TruststoreKey]).ShouldNot(BeNil())
-				Expect(secret.Data[legobridge.PKCS12SecretKey]).ShouldNot(BeNil())
+				Eventually(func(g Gomega) {
+					secret, err = u.GetSecret("cert3-secret")
+					g.Expect(err).ShouldNot(HaveOccurred())
+					g.Expect(secret.Data).Should(HaveLen(7))
+					g.Expect(secret.Data[legobridge.JKSTruststoreKey]).ShouldNot(BeNil())
+					g.Expect(secret.Data[legobridge.JKSSecretKey]).ShouldNot(BeNil())
+					g.Expect(secret.Data[legobridge.PKCS12TruststoreKey]).ShouldNot(BeNil())
+					g.Expect(secret.Data[legobridge.PKCS12SecretKey]).ShouldNot(BeNil())
+				}).Should(Succeed())
 			})
 
 			By("check secret labels in cert3", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind flake

**What this PR does / why we need it**:
Fix flaky check for keystore data in certificate secret.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
