### PR TITLE
Cleanup status for orphan pending certificate resources

### DIFF
--- a/pkg/cert/legobridge/pki_test.go
+++ b/pkg/cert/legobridge/pki_test.go
@@ -63,8 +63,8 @@ var _ = Describe("PKI", func() {
 			Expect(cert.Subject.CommonName).To(Equal(*input.CommonName))
 			Expect(cert.DNSNames).To(ContainElement(input.DNSNames[0]))
 			Expect(cert.IsCA).To(BeTrue())
-			Expect(cert.NotBefore).To(BeTemporally("~", expectedNotBefore, time.Second))
-			Expect(cert.NotAfter).To(BeTemporally("~", expectedNotAfter, time.Second))
+			Expect(cert.NotBefore).To(BeTemporally("~", expectedNotBefore, 3*time.Second))
+			Expect(cert.NotAfter).To(BeTemporally("~", expectedNotAfter, 3*time.Second))
 
 			By("Decoding the certificate private key")
 			p, _ = pem.Decode(certPrivateKeyPEM)

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -181,7 +181,7 @@ func (r *certReconciler) Start() error {
 		}
 	} else {
 		if err := r.cleanupOrphanDNSRecordsFromOldChallenges(); err != nil {
-			return err
+			return fmt.Errorf("failed cleaning up orphaned DNS records: %w", err)
 		}
 	}
 

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -186,7 +186,7 @@ func (r *certReconciler) Start() error {
 	}
 
 	if err := r.cleanupOrphanOutdatedCertificateSecrets(); err != nil {
-		return err
+		return fmt.Errorf("failed cleaning up orphaned, outdated certificate secrets: %w", err)
 	}
 	r.garbageCollectorTicker = time.NewTicker(7 * 24 * time.Hour)
 	go func() {

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -177,7 +177,7 @@ type certReconciler struct {
 func (r *certReconciler) Start() error {
 	if !r.useDNSRecords {
 		if err := r.cleanupOrphanDNSEntriesFromOldChallenges(); err != nil {
-			return err
+			return fmt.Errorf("failed cleaning up orphaned DNS entries: %w", err)
 		}
 	} else {
 		if err := r.cleanupOrphanDNSRecordsFromOldChallenges(); err != nil {

--- a/pkg/controller/issuer/reconciler.go
+++ b/pkg/controller/issuer/reconciler.go
@@ -91,8 +91,8 @@ func (r *compoundReconciler) setupIssuers(cluster utils.Cluster) error {
 	return nil
 }
 
-func (r *compoundReconciler) Start() {
-	r.certificateReconciler.(reconcile.LegacyStartInterface).Start()
+func (r *compoundReconciler) Start() error {
+	return r.certificateReconciler.(reconcile.StartInterface).Start()
 }
 
 func (r *compoundReconciler) Reconcile(logger logger.LogContext, obj resources.Object) reconcile.Status {

--- a/test/integration/controller/issuer/issuer_suite_test.go
+++ b/test/integration/controller/issuer/issuer_suite_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/mappings"
+	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	dnsapi "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -169,6 +171,7 @@ func doInit() {
 
 	utils.Must(resources.Register(v1alpha1.SchemeBuilder))
 	utils.Must(resources.Register(apiextensionsv1.SchemeBuilder))
+	utils.Must(resources.Register(dnsapi.SchemeBuilder))
 	utils.Must(resources.Register(runtime.SchemeBuilder{kubernetesscheme.AddToScheme}))
 }
 
@@ -182,4 +185,9 @@ func runControllerManager(ctx context.Context, args []string) {
 	if err := command.Execute(); err != nil {
 		log.Error(err, "controllermanager command failed")
 	}
+}
+
+func newContext() {
+	ctx0 := ctxutil.CancelContext(ctxutil.WaitGroupContext(context.Background(), "main"))
+	ctx = ctxutil.TickContext(ctx0, controllermanager.DeletionActivity)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
If a cert-manager controller is killed for any reason during there is a certificate with state `Pending`, the resource will stay in this state forever.
This PR provides a fix for this edge case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Cleanup status for orphan pending certificate resources
```
