### PR TITLE
Fix panic if target issuer referenced but not allowed

### DIFF
--- a/pkg/controller/issuer/acme/handler.go
+++ b/pkg/controller/issuer/acme/handler.go
@@ -126,7 +126,11 @@ func (r *acmeIssuerHandler) Reconcile(logger logger.LogContext, obj resources.Ob
 		if err != nil {
 			return r.failedAcme(logger, obj, api.StateError, fmt.Errorf("registration marshalling failed: %w", err))
 		}
-		newObj, err := r.support.GetIssuerResources(issuerKey).Update(issuer)
+		issuerResources, err := r.support.GetIssuerResources(issuerKey)
+		if err != nil {
+			return r.failedAcme(logger, obj, api.StateError, fmt.Errorf("invalid issuer: %w", err))
+		}
+		newObj, err := issuerResources.Update(issuer)
 		if err != nil {
 			return r.failedAcmeRetry(logger, obj, api.StateError, fmt.Errorf("updating resource failed: %w", err))
 		}

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -572,8 +572,12 @@ func (r *certReconciler) restoreCA(issuerKey utils.IssuerKey, issuer *api.Issuer
 		return nil, fmt.Errorf("CA registration? missing in status")
 	}
 	issuerSecretObjectName := resources.NewObjectName(secretRef.Namespace, secretRef.Name)
+	secretResources, err := r.support.GetIssuerSecretResources(issuerKey)
+	if err != nil {
+		return nil, fmt.Errorf("fetching issuer secret failed: %w", err)
+	}
 	issuerSecret := &corev1.Secret{}
-	_, err := r.support.GetIssuerSecretResources(issuerKey).GetInto(issuerSecretObjectName, issuerSecret)
+	_, err = secretResources.GetInto(issuerSecretObjectName, issuerSecret)
 	if err != nil {
 		return nil, fmt.Errorf("fetching issuer secret failed: %w", err)
 	}

--- a/pkg/controller/issuer/core/support.go
+++ b/pkg/controller/issuer/core/support.go
@@ -89,6 +89,7 @@ func NewHandlerSupport(c controller.Interface) (*Support, error) {
 		defaultSecretResources: defaultSecretResources,
 		targetIssuerResources:  targetIssuerResources,
 		targetSecretResources:  targetSecretResources,
+		targetIssuerAllowed:    allowTargetIssuers,
 		defaultCluster:         defaultCluster,
 		targetCluster:          targetCluster,
 	}
@@ -221,6 +222,7 @@ type Support struct {
 	defaultSecretResources     resources.Interface
 	targetIssuerResources      resources.Interface
 	targetSecretResources      resources.Interface
+	targetIssuerAllowed        bool
 	defaultIssuerName          string
 	issuerNamespace            string
 	defaultRequestsPerDayQuota int
@@ -262,7 +264,11 @@ func (s *Support) WriteIssuerSecretFromRegistrationUser(issuerKey utils.IssuerKe
 		return nil, nil, err
 	}
 
-	obj, err := s.GetIssuerSecretResources(issuerKey).CreateOrUpdate(secret)
+	secretResources, err := s.GetIssuerSecretResources(issuerKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting issuer secret resources failed: %w", err)
+	}
+	obj, err := secretResources.CreateOrUpdate(secret)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating/updating issuer secret failed: %w", err)
 	}
@@ -278,7 +284,11 @@ func (s *Support) UpdateIssuerSecret(issuerKey utils.IssuerKey, reguser *legobri
 	if err != nil {
 		return err
 	}
-	obj, err := s.GetIssuerSecretResources(issuerKey).Wrap(secret)
+	secretResources, err := s.GetIssuerSecretResources(issuerKey)
+	if err != nil {
+		return fmt.Errorf("getting issuer secret resources failed: %w", err)
+	}
+	obj, err := secretResources.Wrap(secret)
 	if err != nil {
 		return fmt.Errorf("wrapping issuer secret failed: %w", err)
 	}
@@ -292,11 +302,14 @@ func (s *Support) UpdateIssuerSecret(issuerKey utils.IssuerKey, reguser *legobri
 
 // ReadIssuerSecret reads a issuer secret
 func (s *Support) ReadIssuerSecret(issuerKey utils.IssuerKey, ref *corev1.SecretReference) (*corev1.Secret, error) {
-	res := s.GetIssuerSecretResources(issuerKey)
+	secretResources, err := s.GetIssuerSecretResources(issuerKey)
+	if err != nil {
+		return nil, fmt.Errorf("getting issuer secret resources failed: %w", err)
+	}
 
 	secret := &corev1.Secret{}
 	objName := resources.NewObjectName(ref.Namespace, ref.Name)
-	_, err := res.GetInto(objName, secret)
+	_, err = secretResources.GetInto(objName, secret)
 	if err != nil {
 		return nil, err
 	}
@@ -663,25 +676,31 @@ func (s *Support) IsDefaultIssuer(issuerKey utils.IssuerKey) bool {
 }
 
 // GetIssuerResources returns the resources for issuer.
-func (s *Support) GetIssuerResources(issuerKey utils.IssuerKey) resources.Interface {
+func (s *Support) GetIssuerResources(issuerKey utils.IssuerKey) (resources.Interface, error) {
 	switch issuerKey.Cluster() {
 	case utils.ClusterDefault:
-		return s.defaultIssuerResources
+		return s.defaultIssuerResources, nil
 	case utils.ClusterTarget:
-		return s.targetIssuerResources
+		if !s.targetIssuerAllowed {
+			return nil, fmt.Errorf("target issuers not allowed")
+		}
+		return s.targetIssuerResources, nil
 	}
-	return nil
+	return nil, fmt.Errorf("unexpected issuer cluster: %s", issuerKey.Cluster())
 }
 
 // GetIssuerSecretResources returns the resources for issuer secrets.
-func (s *Support) GetIssuerSecretResources(issuerKey utils.IssuerKey) resources.Interface {
+func (s *Support) GetIssuerSecretResources(issuerKey utils.IssuerKey) (resources.Interface, error) {
 	switch issuerKey.Cluster() {
 	case utils.ClusterDefault:
-		return s.defaultSecretResources
+		return s.defaultSecretResources, nil
 	case utils.ClusterTarget:
-		return s.targetSecretResources
+		if !s.targetIssuerAllowed {
+			return nil, fmt.Errorf("target issuers not allowed")
+		}
+		return s.targetSecretResources, nil
 	}
-	return nil
+	return nil, fmt.Errorf("unexpected issuer cluster: %s", issuerKey.Cluster())
 }
 
 // CalcSecretHash calculates the secret hash
@@ -742,7 +761,7 @@ func (s *Support) ClearCertRevoked(certName resources.ObjectName) {
 	}
 }
 
-// GetAllRevoked gets all certificate object object names which are revoked
+// GetAllRevoked gets all certificate object names which are revoked
 func (s *Support) GetAllRevoked() []resources.ObjectName {
 	return s.state.GetAllRevoked()
 }
@@ -754,9 +773,12 @@ func (s *Support) reportRevokedCount() {
 
 // LoadIssuer loads the issuer for the given Certificate
 func (s *Support) LoadIssuer(issuerKey utils.IssuerKey) (*api.Issuer, error) {
-	res := s.GetIssuerResources(issuerKey)
+	issuerResources, err := s.GetIssuerResources(issuerKey)
+	if err != nil {
+		return nil, err
+	}
 	issuer := &api.Issuer{}
-	_, err := res.GetInto(issuerKey.ObjectName(s.IssuerNamespace()), issuer)
+	_, err = issuerResources.GetInto(issuerKey.ObjectName(s.IssuerNamespace()), issuer)
 	if err != nil {
 		return nil, fmt.Errorf("fetching issuer failed: %w", err)
 	}

--- a/pkg/controller/issuer/core/support.go
+++ b/pkg/controller/issuer/core/support.go
@@ -686,7 +686,7 @@ func (s *Support) GetIssuerResources(issuerKey utils.IssuerKey) (resources.Inter
 		}
 		return s.targetIssuerResources, nil
 	}
-	return nil, fmt.Errorf("unexpected issuer cluster: %s", issuerKey.Cluster())
+	return nil, fmt.Errorf("unexpected issuer cluster: %s", issuerKey.ClusterName())
 }
 
 // GetIssuerSecretResources returns the resources for issuer secrets.
@@ -700,7 +700,7 @@ func (s *Support) GetIssuerSecretResources(issuerKey utils.IssuerKey) (resources
 		}
 		return s.targetSecretResources, nil
 	}
-	return nil, fmt.Errorf("unexpected issuer cluster: %s", issuerKey.Cluster())
+	return nil, fmt.Errorf("unexpected issuer cluster: %s", issuerKey.ClusterName())
 }
 
 // CalcSecretHash calculates the secret hash

--- a/pkg/controller/issuer/reconciler.go
+++ b/pkg/controller/issuer/reconciler.go
@@ -77,8 +77,11 @@ func (r *compoundReconciler) Setup() error {
 
 func (r *compoundReconciler) setupIssuers(cluster utils.Cluster) error {
 	dummyKey := utils.NewIssuerKey(cluster, "dummy", "dummy")
-	res := r.handler.Support().GetIssuerResources(dummyKey)
-	list, err := res.Namespace(r.handler.Support().IssuerNamespace()).List(v1.ListOptions{})
+	issuerResources, err := r.handler.Support().GetIssuerResources(dummyKey)
+	if err != nil {
+		return fmt.Errorf("cannot get issuer resources: %w", err)
+	}
+	list, err := issuerResources.Namespace(r.handler.Support().IssuerNamespace()).List(v1.ListOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
After introducing self-signed issuers (PR #228 ) a regression bug was introduced if a certificate references a target issuer (shoot issuer) but target issuer are not allowed by command-line option `--allow-target-issuer=false`.

**Which issue(s) this PR fixes**:
Fixes #
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix panic if target issuer referenced but not allowed
```
