### PR TITLE
docs: Document gaps to the community `cert-manager`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Some details about the CA can be found in the status of the issuer.
 </details>
 
 ### SelfSigned
+
 This issuer is meant to be used when you want to create a fully managed self-signed certificate.
 
 Configure your shoot to allow custom issuers in the shoot cluster. By default, issuers are created in the control plane of your cluster.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The cert-controller-manager runs in a **secured cluster** where the issuer secre
 At the same time it watches an untrusted **source cluster** and can provide certificates for it.
 The cert-controller-manager relies on DNS challenges (ACME only) for validating the domain names of the certificates.
 For this purpose it creates DNSEntry custom resources (in a possible separate **dns cluster**) to be
-handled by the compagnion dns-controller-manager from [external-dns-management](https://github.com/gardener/external-dns-management).
+handled by the companion dns-controller-manager from [external-dns-management](https://github.com/gardener/external-dns-management).
 
 Currently, the `cert-controller-manager` supports certificate authorities via:
 
@@ -142,7 +142,7 @@ issuer-staging   https://acme-staging-v02.api.letsencrypt.org/directory   some.u
 This issuer is meant to be used where a central Certificate Authority
 is already in place. The operator must request/provide by its own means a CA
 or an intermediate CA. This is mainly used for **on-premises** and
-**airgapped** environements.
+**air-gapped** environments.
 
 To create a self-signed certificate a dedicated issuer of type [selfSigned](#selfsigned) should be used. 
 
@@ -859,7 +859,7 @@ See the [Gateway API tutorial](docs/usage/tutorials/gateway-api-gateways.md) for
 
 ## Using the cert-controller-manager
 
-The cert-controller-manager communicated with up to four different clusters:
+The cert-controller-manager communicates with up to four different clusters:
 - **default** 
   used for managing issuers and lease management.
   The path to the kubeconfig is specified with command line option `--kubeconfig`.
@@ -1040,7 +1040,7 @@ The configuration can be changed with the command line parameter `--issuer.renew
 ## Revoking Certificates
 
 Certificates created with an `ACME` issuer can also be revoked if private key of the certificate
-is not longer safe. This page about [Revoking certificates on Let's Encrypt](https://letsencrypt.org/docs/revoking/)
+is no longer safe. This page about [Revoking certificates on Let's Encrypt](https://letsencrypt.org/docs/revoking/)
 list various reasons:
 > For instance, you might accidentally share the private key on a public website; hackers might copy the private key off 
 > of your servers; or hackers might take temporary control over your servers or your DNS configuration, and use that to
@@ -1114,7 +1114,7 @@ The `cert-controller-manager` will then perform several steps.
 
 With this variant the certificate is renewed, before the old one(s) are revoked. This means the 
 certificate secrets of the `Certificate` objects will contain newly requested certificates and
-the old certificate(s) will be revoked afterwards.
+the old certificate(s) will be revoked afterward.
 
 For this purpose, set `renew: true` in the spec of the `CertificateRevocation` object:
 
@@ -1198,7 +1198,7 @@ With the command line option `--use-dnsrecords`, the cert-controller-manager cre
 
 ## Troubleshooting
 
-Requesting certificates from an ACME provider (like Let's encrypt) is always performed using a DNS01 challenge.
+Requesting certificates from an ACME provider (like Let's Encrypt) is always performed using a DNS01 challenge.
 For this purpose, the `cert-controller-manager` creates an `DNSEntry` for the `dns-controller-manager`
 (see project [external-dns-management](https://github.com/gardener/external-dns-management)).
 Your `dns-controller-manager` needs a suitable `DNSProvider` responsible for the domain(s) of the common name and further
@@ -1221,7 +1221,7 @@ Here are the two most frequent ones.
    LAST SEEN   TYPE      REASON      OBJECT               MESSAGE
    10m         Warning   reconcile   certificate/mycert   obtaining certificate failed: error: one or more domains had a problem: [mycert.<mydomain>] time limit exceeded . Details: DNS TXT record '_acme-challenge.mycert.<mydomain>' is not visible on public (or precheck) name servers. Failed check: DNS record propagation
    ```
-   This means the DNS TXT record could not be looked up by the configurated "precheck" nameservers. With the default configuration, these are some public DNS servers.
+   This means the DNS TXT record could not be looked up by the configured "precheck" nameservers. With the default configuration, these are some public DNS servers.
    In this case, check if the configured `DNSProvider` uses a private hosted zone or if the "precheck" nameservers need to be adjusted to your use case.
    There may also some configuration of the hosted zone itself (i.e. generic CNAME forwarding) which may cause problems. 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently, the `cert-controller-manager` supports certificate authorities via:
       - [Auto registration](#auto-registration)
       - [Using existing account](#using-existing-account)
     - [Certificate Authority (CA)](#certificate-authority-ca)
+    - [SelfSigned](#selfsigned)
   - [Requesting a Certificate](#requesting-a-certificate)
     - [Using `commonName` and optional `dnsNames`](#using-commonname-and-optional-dnsnames)
     - [Follow CNAME](#follow-cname)

--- a/README.md
+++ b/README.md
@@ -677,72 +677,6 @@ if it has exactly the same common name and DNS names.
 The annotation `cert.gardener.cloud/secret-namespace` can be used to change the namespace, the TLS secret is created in.
 By default, it is created in the same namespace as the service. 
 
-## Demo quick start
-
-1. Run dns-controller-manager with:
-
-    ```bash
-    ./dns-controller-manager --controllers=azure-dns --identifier=myOwnerId --disable-namespace-restriction
-    ```
-
-2. Ensure provider and its secret, e.g.
-
-    ```bash
-    kubectl apply -f azure-secret.yaml
-    kubectl apply -f azure-provider.yaml
-    ```
-
-   - check with
-
-        ```bash
-        ▶ kubectl get dnspr
-        NAME               TYPE        STATUS   AGE
-        azure-playground   azure-dns   Ready    28m
-        ```
-
-3. Create test namespace
-
-    ```bash
-    kubectl create ns test
-    ```
-
-4. Run cert-controller-manager
-
-    ```bash
-    ./cert-controller-manager
-    ```
-
-5. Register user `some.user@mydomain.com` at let's encrypt
-
-    ```bash
-    kubectl apply -f examples/20-issuer-staging.yaml
-    ```
-
-   - check with
-
-        ```bash
-        ▶ kubectl get issuer
-        NAME             SERVER                                                   EMAIL                    STATUS   TYPE   AGE
-        issuer-staging   https://acme-staging-v02.api.letsencrypt.org/directory   some.user@mydomain.com   Ready    acme   8s
-        ```
-
-6. Request a certificate for `cert1.martin.test6227.ml`
-
-    ```bash
-    kubectl apply -f examples/30-cert-simple.yaml
-    ```
-
-    If this certificate has been already registered for the same issuer before,
-    it will be returned immediately from the ACME server.
-    Otherwise a DNS challenge is started using a temporary DNSEntry to be set by `dns-controller-manager`
-
-   - check with
-
-        ```bash
-        ▶ kubectl get cert -o wide
-        NAME          COMMON NAME           ISSUER           STATUS   EXPIRATION_DATE        DNS_NAMES                 AGE
-        cert-simple   cert1.mydomain.com    issuer-staging   Ready    2019-11-10T09:48:17Z   [cert1.my-domain.com]     34s
-        ```
 ## Requesting a Certificate for Gateways
 
 There are source controllers for `Gateways` from [Istio](https://github.com/istio/istio) or the new 
@@ -858,6 +792,73 @@ spec:
 In this case, a single `Certificate` resource with domain name `foo.example.com` would be created.
 
 See the [Gateway API tutorial](docs/usage/tutorials/gateway-api-gateways.md) for a more detailed example.
+
+## Demo quick start
+
+1. Run dns-controller-manager with:
+
+    ```bash
+    ./dns-controller-manager --controllers=azure-dns --identifier=myOwnerId --disable-namespace-restriction
+    ```
+
+2. Ensure provider and its secret, e.g.
+
+    ```bash
+    kubectl apply -f azure-secret.yaml
+    kubectl apply -f azure-provider.yaml
+    ```
+
+    - check with
+
+         ```bash
+         ▶ kubectl get dnspr
+         NAME               TYPE        STATUS   AGE
+         azure-playground   azure-dns   Ready    28m
+         ```
+
+3. Create test namespace
+
+    ```bash
+    kubectl create ns test
+    ```
+
+4. Run cert-controller-manager
+
+    ```bash
+    ./cert-controller-manager
+    ```
+
+5. Register user `some.user@mydomain.com` at Let's Encrypt
+
+    ```bash
+    kubectl apply -f examples/20-issuer-staging.yaml
+    ```
+
+    - check with
+
+         ```bash
+         ▶ kubectl get issuer
+         NAME             SERVER                                                   EMAIL                    STATUS   TYPE   AGE
+         issuer-staging   https://acme-staging-v02.api.letsencrypt.org/directory   some.user@mydomain.com   Ready    acme   8s
+         ```
+
+6. Request a certificate for `cert1.martin.test6227.ml`
+
+    ```bash
+    kubectl apply -f examples/30-cert-simple.yaml
+    ```
+
+   If this certificate has been already registered for the same issuer before,
+   it will be returned immediately from the ACME server.
+   Otherwise, a DNS challenge is started using a temporary DNSEntry to be set by `dns-controller-manager`
+
+    - check with
+
+         ```bash
+         ▶ kubectl get cert -o wide
+         NAME          COMMON NAME           ISSUER           STATUS   EXPIRATION_DATE        DNS_NAMES                 AGE
+         cert-simple   cert1.mydomain.com    issuer-staging   Ready    2019-11-10T09:48:17Z   [cert1.my-domain.com]     34s
+         ```
 
 ## Using the cert-controller-manager
 

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ spec:
         key: password  
 ```
 
-## Requesting a Certificate for Ingress 
+## Requesting a Certificate for Ingress
 
 Add the annotation `cert.gardener.cloud/purpose: managed` to the Ingress resource.
 The `cert-controller-manager` will then automatically request a certificate for all domains given by the hosts in the
@@ -616,7 +616,7 @@ See also [examples/40-ingress-echoheaders.yaml](./examples/40-ingress-echoheader
 
    The certificate is stored in the secret as specified in the Ingress resource.
 
-## Requesting a Certificate for Service 
+## Requesting a Certificate for Service
 
 If you have a service of type `LoadBalancer`, you can use the annotation `cert.gardener.cloud/secretname` together
 with the annotation `dns.gardener.cloud/dnsnames` from the `dns-controller-manager` to trigger automatic creation of 

--- a/README.md
+++ b/README.md
@@ -1253,7 +1253,6 @@ The following list differentiates reasons based on the effort that would be requ
    Gardener's `cert-management` supports both Kubernetes `Gateway` and Istio `Gateway` resources.
 
 5. ⚠️ It is not possible to annotate `Service` resources of type `LoadBalancer` in the `cert-manager` project ([ref](https://cert-manager.io/docs/usage/)).
-   Gardener's `cert-management` supports such an annotation.
 
 6. ⛔️ There is no reuse of existing certificates in the `cert-manager` project.
    This means that if a certificate is requested multiple times, it will be issued multiple times.

--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ See the [Gateway API tutorial](docs/usage/tutorials/gateway-api-gateways.md) for
          issuer-staging   https://acme-staging-v02.api.letsencrypt.org/directory   some.user@mydomain.com   Ready    acme   8s
          ```
 
-6. Request a certificate for `cert1.martin.test6227.ml`
+6. Request a certificate for `cert1.my-domain.com`
 
     ```bash
     kubectl apply -f examples/30-cert-simple.yaml

--- a/README.md
+++ b/README.md
@@ -1262,7 +1262,7 @@ The following list differentiates reasons based on the effort that would be requ
    Gardener's `cert-management` uses the companion `dns-controller-manager` from [external-dns-management](https://github.com/gardener/external-dns-management) to solve DNS-01 challenges (possibly in a separate DNS cluster). 
    This would require developing a webhook `Issuer` for `cert-manager` to integrate with the `dns-controller-manager` ([ref](https://cert-manager.io/docs/configuration/acme/dns01/webhook/)).
 
-8. ⛔️ Private keys for the ACME `Issuer` have to be stored in the same cluster as the `cert-manager` controller is running in ([ref](https://github.com/cert-manager/cert-manager/issues/756)).
+8. ⛔️ Private keys for the ACME `Issuer` have to be stored in the same cluster as the `cert-manager` controller is running in ([ref](https://github.com/cert-manager/cert-manager/issues/756)). This is an essential requirement for a hosted control-plane solution like Gardener, where issuers and especially their secrets should remain opaque to end-users.
    Gardener's `cert-management` allows to separate `Issuer` and `Certificate` resources in different clusters.
 
 9. ⛔️ There's no dynamic watch support for Istio `Gateway` resources in the `cert-manager` project since it only supports Kubernetes `Gateway`s.

--- a/README.md
+++ b/README.md
@@ -1259,7 +1259,7 @@ The following list differentiates reasons based on the effort that would be requ
    Gardener's `cert-management` reuses existing certificates if the common name and DNS names match.
 
 7. ⛔️ The ACME DNS-01 challenge is represented through the custom resources `DNSEntry` and `DNSRecord` in the `cert-manager` project.
-   Gardener's `cert-management` uses the companion `dns-controller-manager` from [external-dns-management](https://github.com/gardener/external-dns-management) to solve DNS-01 challenges (in a possible separate DNS cluster). 
+   Gardener's `cert-management` uses the companion `dns-controller-manager` from [external-dns-management](https://github.com/gardener/external-dns-management) to solve DNS-01 challenges (possibly in a separate DNS cluster). 
    This would require developing a webhook `Issuer` for `cert-manager` to integrate with the `dns-controller-manager` ([ref](https://cert-manager.io/docs/configuration/acme/dns01/webhook/)).
 
 8. ⛔️ Private keys for the ACME `Issuer` have to be stored in the same cluster as the `cert-manager` controller is running in ([ref](https://github.com/cert-manager/cert-manager/issues/756)).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR documents the gaps between the ☸️ community [`cert-manager`](https://[cert-manager](https://cert-manager.io/).io/) and 🧑‍🌾 Gardener's [`cert-management`](https://github.com/gardener/cert-management) (Similar to the list of differentiating features documented in [external-dns-management](https://github.com/gardener/external-dns-management#why-not-using-the-community-external-dns-solution)).

It is not intended to point out a lack of features in either project but rather to document the differences to provide an easy lookup reference. It also allows us to revisit the list in the future to see whether the projects are more closely aligned.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel @timuthy @rfranzke @vlerenc @ScheererJ @oliver-goetz @tobschli

The primary change is:
https://github.com/gardener/cert-management/commit/bf54a78ad9a51a7b4d5e2984627f38bf0c483169

All other changes are typo fixes, Markdown formatting, and tidying up sections.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
Document gaps between the community `cert-manager` and Gardener's `cert-management`.
```
