### PR TITLE
Support `DNSRecord.spec.class` by annotation `cert.gardener.cloud/dnsrecord-class`

### DIFF
--- a/examples/30-cert-simple.yaml
+++ b/examples/30-cert-simple.yaml
@@ -11,6 +11,7 @@ metadata:
     # annotations needed when using DNSRecords
     #cert.gardener.cloud/dnsrecord-provider-type: aws-route53
     #cert.gardener.cloud/dnsrecord-secret-ref: myns/mysecret
+    #cert.gardener.cloud/dnsrecord-class: garden # optional, only required on Garden runtime cluster
   name: cert-simple
   namespace: default
 spec:

--- a/pkg/cert/legobridge/certificate.go
+++ b/pkg/cert/legobridge/certificate.go
@@ -97,6 +97,8 @@ type DNSRecordSettings struct {
 	Type string
 	// SecretRef is a reference to a secret that contains the cloud provider specific credentials.
 	SecretRef corev1.SecretReference
+	// Class is the optional extension class for the DNS record.
+	Class string
 }
 
 // ObtainOutput is the result of the certificate obtain request.

--- a/pkg/cert/legobridge/dnsrecordprovider.go
+++ b/pkg/cert/legobridge/dnsrecordprovider.go
@@ -59,6 +59,9 @@ func (p *dnsRecordProvider) present(log logger.LogContext, domain, fqdn string, 
 		e.Spec.Type = p.settings.DNSRecordSettings.Type
 		e.Spec.SecretRef = p.settings.DNSRecordSettings.SecretRef
 		e.Spec.Values = values
+		if p.settings.DNSRecordSettings.Class != "" {
+			e.Spec.Class = ptr.To(extensionsv1alpha.ExtensionClass(p.settings.DNSRecordSettings.Class))
+		}
 		resources.SetAnnotation(e, source.AnnotACMEDNSChallenge, "true")
 	}
 

--- a/pkg/cert/source/controller.go
+++ b/pkg/cert/source/controller.go
@@ -51,6 +51,8 @@ const (
 	AnnotDNSRecordProviderType = api.GroupName + "/dnsrecord-provider-type"
 	// AnnotDNSRecordSecretRef is the annotation for providing the secret ref for DNS records.
 	AnnotDNSRecordSecretRef = api.GroupName + "/dnsrecord-secret-ref"
+	// AnnotDNSRecordClass is an optional annotation for providing the extension class for DNS records.
+	AnnotDNSRecordClass = api.GroupName + "/dnsrecord-class"
 
 	// AnnotPrivateKeyAlgorithm is the annotation key to set the PrivateKeyAlgorithm for a Certificate.
 	// If PrivateKeyAlgorithm is specified and `size` is not provided,

--- a/pkg/cert/source/utils.go
+++ b/pkg/cert/source/utils.go
@@ -33,7 +33,7 @@ func ExtractSecretLabels(objData resources.ObjectData) (secretLabels map[string]
 
 // CopyDNSRecordsAnnotations extracts DNSRecord related annotations.
 func CopyDNSRecordsAnnotations(data resources.ObjectData) (annotations map[string]string) {
-	for _, annotKey := range []string{AnnotDNSRecordProviderType, AnnotDNSRecordSecretRef} {
+	for _, annotKey := range []string{AnnotDNSRecordProviderType, AnnotDNSRecordSecretRef, AnnotDNSRecordClass} {
 		if value := data.GetAnnotations()[annotKey]; value != "" {
 			if annotations == nil {
 				annotations = map[string]string{}

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -1480,5 +1480,6 @@ func createDNSRecordSettings(cert *api.Certificate) (*legobridge.DNSRecordSettin
 	return &legobridge.DNSRecordSettings{
 		Type:      typ,
 		SecretRef: secretRef,
+		Class:     cert.Annotations[source.AnnotDNSRecordClass],
 	}, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Allow to specify the extension class for a DNS challenge using `DNSRecords` by setting the annotation `cert.gardener.cloud/dnsrecord-class`. It is needed for Gardener internal purposes only. If a `Certificate` is created on the Garden runtime cluster, the `TXT` record for the DNS challenge is created via `DNSRecords` resources. Only `DNSRecords` with `.spec.class=garden` will be managed by the provider extension running there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support `DNSRecord.spec.class` by annotation `cert.gardener.cloud/dnsrecord-class`
```
