### PR TITLE
Add Make Target to execute Unit Tests with Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ tmp/
 .vscode/
 .kubeconfig-kind-integration
 
+*.coverprofile
+*.html
+
 # gosec
 gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ test: $(GINKGO)
 test-integration: $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
 	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/integration/...
 
+.PHONY: test-cov
+test-cov:
+	@bash $(GARDENER_HACK_DIR)/test-cover.sh ./pkg/... ./cmd/...
+
 .PHONY: generate
 generate: $(VGOPATH) $(CONTROLLER_GEN)
 	@GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) ./hack/generate-code

--- a/pkg/cert/legobridge/cakeypair_test.go
+++ b/pkg/cert/legobridge/cakeypair_test.go
@@ -61,12 +61,8 @@ var _ = Describe("PKI Helpers", func() {
 		})
 
 		It("returns error if TLSCertKey is missing", func() {
-			By("Creating a certificate")
-			priv, err := rsa.GenerateKey(rand.Reader, 2048)
-			Expect(err).To(Succeed())
-			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
-			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
-			Expect(err).To(Succeed())
+			data := createCertificateFromRSAKey()
+			var err error
 
 			By("Removing the TLSCertKey")
 			delete(data, corev1.TLSCertKey)
@@ -76,12 +72,8 @@ var _ = Describe("PKI Helpers", func() {
 		})
 
 		It("returns error if TLSCertKey is empty", func() {
-			By("Creating a certificate")
-			priv, err := rsa.GenerateKey(rand.Reader, 2048)
-			Expect(err).To(Succeed())
-			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
-			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
-			Expect(err).To(Succeed())
+			data := createCertificateFromRSAKey()
+			var err error
 
 			By("Removing the TLSCertKey data")
 			data[corev1.TLSCertKey] = []byte{}
@@ -91,12 +83,8 @@ var _ = Describe("PKI Helpers", func() {
 		})
 
 		It("returns error if TLSPrivateKeyKey is missing", func() {
-			By("Creating a certificate")
-			priv, err := rsa.GenerateKey(rand.Reader, 2048)
-			Expect(err).To(Succeed())
-			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
-			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
-			Expect(err).To(Succeed())
+			data := createCertificateFromRSAKey()
+			var err error
 
 			By("Removing the TLSPrivateKeyKey")
 			delete(data, corev1.TLSPrivateKeyKey)
@@ -106,12 +94,8 @@ var _ = Describe("PKI Helpers", func() {
 		})
 
 		It("returns error if TLSPrivateKeyKey is empty", func() {
-			By("Creating a certificate")
-			priv, err := rsa.GenerateKey(rand.Reader, 2048)
-			Expect(err).To(Succeed())
-			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
-			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
-			Expect(err).To(Succeed())
+			data := createCertificateFromRSAKey()
+			var err error
 
 			By("Removing the TLSPrivateKeyKey data")
 			data[corev1.TLSPrivateKeyKey] = []byte{}
@@ -121,6 +105,17 @@ var _ = Describe("PKI Helpers", func() {
 		})
 	})
 })
+
+func createCertificateFromRSAKey() map[string][]byte {
+	By("Creating a certificate")
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	ExpectWithOffset(1, err).To(Succeed())
+	keyBytes := x509.MarshalPKCS1PrivateKey(priv)
+	data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
+	ExpectWithOffset(1, err).To(Succeed())
+
+	return data
+}
 
 func createCertificate(privKey crypto.PrivateKey, pubKey crypto.PublicKey, header string, privKeyBytes []byte) (map[string][]byte, error) {
 	template := &x509.Certificate{

--- a/pkg/cert/legobridge/cakeypair_test.go
+++ b/pkg/cert/legobridge/cakeypair_test.go
@@ -59,6 +59,66 @@ var _ = Describe("PKI Helpers", func() {
 			_, err = CAKeyPairFromSecretData(data)
 			Expect(err).To(Succeed())
 		})
+
+		It("returns error if TLSCertKey is missing", func() {
+			By("Creating a certificate")
+			priv, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(Succeed())
+			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
+			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
+			Expect(err).To(Succeed())
+
+			By("Removing the TLSCertKey")
+			delete(data, corev1.TLSCertKey)
+
+			_, err = CAKeyPairFromSecretData(data)
+			Expect(err).To(MatchError("`tls.crt` data not found in secret"))
+		})
+
+		It("returns error if TLSCertKey is empty", func() {
+			By("Creating a certificate")
+			priv, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(Succeed())
+			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
+			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
+			Expect(err).To(Succeed())
+
+			By("Removing the TLSCertKey data")
+			data[corev1.TLSCertKey] = []byte{}
+
+			_, err = CAKeyPairFromSecretData(data)
+			Expect(err).To(MatchError("decoding pem for tls.crt from request secret failed"))
+		})
+
+		It("returns error if TLSPrivateKeyKey is missing", func() {
+			By("Creating a certificate")
+			priv, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(Succeed())
+			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
+			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
+			Expect(err).To(Succeed())
+
+			By("Removing the TLSPrivateKeyKey")
+			delete(data, corev1.TLSPrivateKeyKey)
+
+			_, err = CAKeyPairFromSecretData(data)
+			Expect(err).To(MatchError("`tls.key` data not found in secret"))
+		})
+
+		It("returns error if TLSPrivateKeyKey is empty", func() {
+			By("Creating a certificate")
+			priv, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(Succeed())
+			keyBytes := x509.MarshalPKCS1PrivateKey(priv)
+			data, err := createCertificate(priv, priv.Public(), "RSA PRIVATE KEY", keyBytes)
+			Expect(err).To(Succeed())
+
+			By("Removing the TLSPrivateKeyKey data")
+			data[corev1.TLSPrivateKeyKey] = []byte{}
+
+			_, err = CAKeyPairFromSecretData(data)
+			Expect(err).To(MatchError("decoding pem block for private key failed"))
+		})
 	})
 })
 

--- a/pkg/cert/source/reconciler.go
+++ b/pkg/cert/source/reconciler.go
@@ -421,7 +421,7 @@ func (r *sourceReconciler) updateEntry(logger logger.LogContext, info CertInfo, 
 		}
 
 		mod.AssureStringPtrPtr(&spec.CommonName, cn)
-		certutils.AssureStringArray(mod, &spec.DNSNames, dnsNames)
+		certutils.AssureStringSlice(mod, &spec.DNSNames, dnsNames)
 		if info.IssuerName != nil {
 			parts := strings.SplitN(*info.IssuerName, "/", 2)
 			var issuerRef *api.IssuerRef

--- a/pkg/cert/utils/dns_utils_test.go
+++ b/pkg/cert/utils/dns_utils_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package utils_test
 
 import (

--- a/pkg/cert/utils/dns_utils_test.go
+++ b/pkg/cert/utils/dns_utils_test.go
@@ -7,10 +7,7 @@ import (
 )
 
 var _ = Describe("DnsUtils", func() {
-
 	Describe("PreparePrecheckNameservers", func() {
-
-		
 		It("should return given nameservers if they are valid", func() {
 			nameservers := []string{"1.1.1.1:53", "1.1.1.2:53"}
 			Expect(utils.PreparePrecheckNameservers(nameservers)).To(Equal(nameservers))
@@ -22,5 +19,4 @@ var _ = Describe("DnsUtils", func() {
 			Expect(utils.PreparePrecheckNameservers(nameservers)).To(Equal(nameserversExpected))
 		})
 	})
-
 })

--- a/pkg/cert/utils/dns_utils_test.go
+++ b/pkg/cert/utils/dns_utils_test.go
@@ -1,0 +1,26 @@
+package utils_test
+
+import (
+	"github.com/gardener/cert-management/pkg/cert/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DnsUtils", func() {
+
+	Describe("PreparePrecheckNameservers", func() {
+
+		
+		It("should return given nameservers if they are valid", func() {
+			nameservers := []string{"1.1.1.1:53", "1.1.1.2:53"}
+			Expect(utils.PreparePrecheckNameservers(nameservers)).To(Equal(nameservers))
+		})
+
+		It("should return given nameservers if they are valid and adds missing ports", func() {
+			nameservers := []string{"1.1.1.1", "1.1.1.2"}
+			nameserversExpected := []string{"1.1.1.1:53", "1.1.1.2:53"}
+			Expect(utils.PreparePrecheckNameservers(nameservers)).To(Equal(nameserversExpected))
+		})
+	})
+
+})

--- a/pkg/cert/utils/domainrange_test.go
+++ b/pkg/cert/utils/domainrange_test.go
@@ -4,35 +4,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package utils
+package utils_test
 
 import (
-	"testing"
+	"github.com/gardener/cert-management/pkg/cert/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestIsInDomainRange(t *testing.T) {
-	table := []struct {
-		domain      string
-		domainRange string
-		wanted      bool
-	}{
-		{"a.b", "b", true},
-		{"A.B", "b", true},
-		{"a.b", ".b", true},
-		{"a.b", "*.B", true},
-		{"a.b", "a.b", true},
-		{"a.b", "c.b", false},
-		{"a.b", "a.b.c", false},
-		{"a.b.c", "b.c", true},
-		{"a.xb.c", "b.c", false},
-		{"a.b", "b.", true},
-		{"a.b.", "b", true},
-	}
-	for _, entry := range table {
-		domainRange := NormalizeDomainRange(entry.domainRange)
-		result := IsInDomainRange(entry.domain, domainRange)
-		if result != entry.wanted {
-			t.Errorf("domain=%s, domainRange=%s: wanted %t", entry.domain, entry.domainRange, entry.wanted)
-		}
-	}
-}
+var _ = Describe("IsInDomainRange", func() {
+	DescribeTable("domain range tests",
+		func(domain, domainRange string, wanted bool) {
+			domainRange = utils.NormalizeDomainRange(domainRange)
+			result := utils.IsInDomainRange(domain, domainRange)
+			Expect(result).To(Equal(wanted))
+		},
+		Entry("a.b in b", "a.b", "b", true),
+		Entry("A.B in b", "A.B", "b", true),
+		Entry("a.b in .b", "a.b", ".b", true),
+		Entry("a.b in *.B", "a.b", "*.B", true),
+		Entry("a.b in a.b", "a.b", "a.b", true),
+		Entry("a.b not in c.b", "a.b", "c.b", false),
+		Entry("a.b not in a.b.c", "a.b", "a.b.c", false),
+		Entry("a.b.c in b.c", "a.b.c", "b.c", true),
+		Entry("a.xb.c not in b.c", "a.xb.c", "b.c", false),
+		Entry("a.b in b.", "a.b", "b.", true),
+		Entry("a.b. in b", "a.b.", "b", true),
+	)
+})

--- a/pkg/cert/utils/domainrange_test.go
+++ b/pkg/cert/utils/domainrange_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("IsInDomainRange", func() {
-	DescribeTable("domain range tests",
+var _ = Describe("DomainRange", func() {
+	DescribeTable("IsInDomainRange",
 		func(domain, domainRange string, wanted bool) {
 			domainRange = utils.NormalizeDomainRange(domainRange)
 			result := utils.IsInDomainRange(domain, domainRange)
@@ -30,5 +30,36 @@ var _ = Describe("IsInDomainRange", func() {
 		Entry("a.xb.c not in b.c", "a.xb.c", "b.c", false),
 		Entry("a.b in b.", "a.b", "b.", true),
 		Entry("a.b. in b", "a.b.", "b", true),
+		Entry("Empty domain range acts as wildcard", "a.b.c", "", true),
 	)
+
+	DescribeTable("IsInDomainRanges",
+		func(domain string, domainRanges []string, wanted bool) {
+			for i, domainRange := range domainRanges {
+				domainRanges[i] = utils.NormalizeDomainRange(domainRange)
+			}
+			result := utils.IsInDomainRanges(domain, domainRanges)
+			Expect(result).To(Equal(wanted))
+		},
+		Entry("a.b in {b}", "a.b", []string{"b"}, true),
+		Entry("a.b in {b, c}", "a.b", []string{"b", "c"}, true),
+		Entry("a.b in {c, b}", "a.b", []string{"c", "b"}, true),
+		Entry("a.b not in {c, d}", "a.b", []string{"c", "d"}, false),
+		Entry("Nil acts as wildcard", "a.b", nil, true),
+	)
+
+	DescribeTable("BestDomainRange",
+		func(domain string, domainRanges []string, wanted string) {
+			for i, domainRange := range domainRanges {
+				domainRanges[i] = utils.NormalizeDomainRange(domainRange)
+			}
+			result := utils.BestDomainRange(domain, domainRanges)
+			Expect(result).To(Equal(wanted))
+		},
+		Entry("a.b in {b} returns b", "a.b", []string{"b"}, "b"),
+		Entry("a.b in {b, c} returns b", "a.b", []string{"b", "c"}, "b"),
+		Entry("a.b.c in {b.c., c} returns b.c", "a.b.c", []string{"b.c", "c"}, "b.c"),
+		Entry("Nil acts as wildcard", "a.b", nil, "*"),
+	)
+
 })

--- a/pkg/cert/utils/issuerkey_test.go
+++ b/pkg/cert/utils/issuerkey_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package utils_test
 
 import (

--- a/pkg/cert/utils/issuerkey_test.go
+++ b/pkg/cert/utils/issuerkey_test.go
@@ -57,6 +57,7 @@ var _ = Describe("IssuerKey", func() {
 			It("should be true for default cluster", func() {
 				Expect(defaultClusterIssuerKey.Secondary()).To(BeTrue())
 			})
+			
 			It("should be false for non default cluster", func() {
 				Expect(targetClusterIssuerKey.Secondary()).To(BeFalse())
 				Expect(randomClusterIssuerKey.Secondary()).To(BeFalse())
@@ -67,9 +68,11 @@ var _ = Describe("IssuerKey", func() {
 			It("should return 'default' for default cluster", func() {
 				Expect(defaultClusterIssuerKey.ClusterName()).To(Equal("default"))
 			})
+			
 			It("should return 'target' for target cluster", func() {
 				Expect(targetClusterIssuerKey.ClusterName()).To(Equal("target"))
 			})
+			
 			It("should return '' for other clusters", func() {
 				Expect(randomClusterIssuerKey.ClusterName()).To(Equal(""))
 			})

--- a/pkg/cert/utils/issuerkey_test.go
+++ b/pkg/cert/utils/issuerkey_test.go
@@ -74,7 +74,5 @@ var _ = Describe("IssuerKey", func() {
 				Expect(randomClusterIssuerKey.ClusterName()).To(Equal(""))
 			})
 		})
-
 	})
-
 })

--- a/pkg/cert/utils/issuerkey_test.go
+++ b/pkg/cert/utils/issuerkey_test.go
@@ -1,0 +1,81 @@
+package utils_test
+
+import (
+	"github.com/gardener/cert-management/pkg/cert/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IssuerKey", func() {
+	Describe("NewIssuerKey", func() {
+		It("should return IssuerKey with empty namespace for DefaultCluster", func() {
+			issuerKey := utils.NewIssuerKey(utils.ClusterDefault, "someNamespace", "Issuer Key Name")
+			Expect(issuerKey.Namespace()).To(Equal(""))
+			Expect(issuerKey.Name()).To(Equal("Issuer Key Name"))
+		})
+
+		It("should return IssuerKey with given namespace for non DefaultCluster", func() {
+			issuerKey := utils.NewIssuerKey(1, "someNamespace", "Issuer Key Name")
+			Expect(issuerKey.Namespace()).To(Equal("someNamespace"))
+			Expect(issuerKey.Name()).To(Equal("Issuer Key Name"))
+		})
+	})
+
+	Describe("NewDefaultClusterIssuerKey", func() {
+		It("should return a new IssuerKey with empty namespace", func() {
+			issuerKey := utils.NewDefaultClusterIssuerKey("Issuer Key Name")
+			Expect(issuerKey.Namespace()).To(Equal(""))
+			Expect(issuerKey.Name()).To(Equal("Issuer Key Name"))
+		})
+	})
+
+	Describe("IssuerKey Methods", func() {
+
+		var (
+			defaultClusterIssuerKey utils.IssuerKey
+			targetClusterIssuerKey  utils.IssuerKey
+			randomClusterIssuerKey  utils.IssuerKey
+		)
+
+		BeforeEach(func() {
+			defaultClusterIssuerKey = utils.NewDefaultClusterIssuerKey("default cluster issuer key")
+			targetClusterIssuerKey = utils.NewIssuerKey(utils.ClusterTarget, "target namespace", "issuer key")
+			randomClusterIssuerKey = utils.NewIssuerKey(3, "random namespace", "issuer key")
+		})
+
+		Describe("NamespaceOrDefault", func() {
+			It("should return the given default for default cluster", func() {
+				Expect(defaultClusterIssuerKey.NamespaceOrDefault("some default")).To(Equal("some default"))
+			})
+
+			It("should return the namespace for non default cluster", func() {
+				Expect(targetClusterIssuerKey.NamespaceOrDefault("some default")).To(Equal(targetClusterIssuerKey.Namespace()))
+				Expect(randomClusterIssuerKey.NamespaceOrDefault("some default")).To(Equal(randomClusterIssuerKey.Namespace()))
+			})
+		})
+
+		Describe("Secondary", func() {
+			It("should be true for default cluster", func() {
+				Expect(defaultClusterIssuerKey.Secondary()).To(BeTrue())
+			})
+			It("should be false for non default cluster", func() {
+				Expect(targetClusterIssuerKey.Secondary()).To(BeFalse())
+				Expect(randomClusterIssuerKey.Secondary()).To(BeFalse())
+			})
+		})
+
+		Describe("ClusterName", func() {
+			It("should return 'default' for default cluster", func() {
+				Expect(defaultClusterIssuerKey.ClusterName()).To(Equal("default"))
+			})
+			It("should return 'target' for target cluster", func() {
+				Expect(targetClusterIssuerKey.ClusterName()).To(Equal("target"))
+			})
+			It("should return '' for other clusters", func() {
+				Expect(randomClusterIssuerKey.ClusterName()).To(Equal(""))
+			})
+		})
+
+	})
+
+})

--- a/pkg/cert/utils/issuerkey_test.go
+++ b/pkg/cert/utils/issuerkey_test.go
@@ -30,7 +30,6 @@ var _ = Describe("IssuerKey", func() {
 	})
 
 	Describe("IssuerKey Methods", func() {
-
 		var (
 			defaultClusterIssuerKey utils.IssuerKey
 			targetClusterIssuerKey  utils.IssuerKey

--- a/pkg/cert/utils/utils_certificate_test.go
+++ b/pkg/cert/utils/utils_certificate_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package utils_test
 
 import (

--- a/pkg/cert/utils/utils_certificate_test.go
+++ b/pkg/cert/utils/utils_certificate_test.go
@@ -1,0 +1,162 @@
+package utils_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"net"
+	"strings"
+
+	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/cert/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UtilsCertificate", func() {
+	var csr []byte
+	var exampleCn string
+	var exampleSan []string
+	var exampleIPs []net.IP
+
+	BeforeEach(func() {
+		exampleCn = "example.com"
+		exampleSan = []string{"www.example.com", "example.org"}
+		exampleIPs = []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("10.0.0.1")}
+	})
+
+	Describe("ExtractCommonNameAnDNSNames", func() {
+
+		Context("Common Name (cn), Subject Alternative Name (san), and IP Addresses are set", func() {
+			It("should extract cn, san, and IP addresses", func() {
+				csr = _createCSR(exampleCn, exampleSan, exampleIPs)
+				cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*cn).To(Equal(exampleCn))
+				Expect(san).To(ContainElements(append(exampleSan, "192.168.1.1", "10.0.0.1")))
+			})
+		})
+
+		Context("Common Name is not set", func() {
+			It("should only return the san and IP addresses", func() {
+				csr = _createCSR("", exampleSan, exampleIPs)
+				cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cn).To(BeNil())
+				Expect(san).To(ContainElements(append(exampleSan, "192.168.1.1", "10.0.0.1")))
+			})
+		})
+
+		Context("CSR is not parseable", func() {
+			It("should fail with an error", func() {
+				csr = []byte("invalid csr")
+				cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("parsing CSR failed: decoding CSR failed"))
+				Expect(cn).To(BeNil())
+				Expect(san).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("ExtractDomains", func() {
+		Context("CommonName or DNSNames are specified", func() {
+			It("should return an error if CSR is not nil", func() {
+				csr = _createCSR("", nil, nil)
+				spec := api.CertificateSpec{
+					CommonName: &exampleCn,
+					DNSNames:   exampleSan,
+					CSR:        csr,
+				}
+
+				dnsNames, err := utils.ExtractDomains(&spec)
+				Expect(dnsNames).To(BeNil())
+				Expect(err).To(MatchError("cannot specify both commonName and csr"))
+			})
+
+			It("should return error if there are >= 100 DNSNames", func() {
+				for i := 0; i <= 100; i++ {
+					exampleSan = append(exampleSan, "example.com")
+				}
+
+				spec := api.CertificateSpec{
+					CommonName: &exampleCn,
+					DNSNames:   exampleSan,
+				}
+
+				dnsNames, err := utils.ExtractDomains(&spec)
+				Expect(dnsNames).To(BeNil())
+				Expect(err).To(MatchError("invalid number of DNS names: 103 (max 99)"))
+			})
+
+			It("should return error if the CommonName is longer than 64", func() {
+				longCommonName := strings.Repeat("a", 65)
+				spec := api.CertificateSpec{
+					CommonName: &longCommonName,
+					DNSNames:   exampleSan,
+				}
+				dnsNames, err := utils.ExtractDomains(&spec)
+				Expect(dnsNames).To(BeNil())
+				Expect(err).To(MatchError("the Common Name is limited to 64 characters (X.509 ASN.1 specification), but first given domain aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa has 65 characters"))
+			})
+
+			It("should return the CommonName and DNSName when both are specified", func ()  {
+				spec := api.CertificateSpec{
+					CommonName: &exampleCn,
+					DNSNames:   exampleSan,
+				}
+
+				dnsNames, err := utils.ExtractDomains(&spec)
+				Expect(dnsNames).To(Equal(append([]string{exampleCn}, exampleSan...)))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Neither CommonName nor DNSNames are specified", func() {
+
+			It("should return error if CSR is not specified either", func() {
+				spec := api.CertificateSpec{}
+				dnsNames, err := utils.ExtractDomains(&spec)
+				Expect(dnsNames).To(BeNil())
+				Expect(err).To(MatchError("either domains or csr must be specified"))
+			})
+
+			It("should extract the DNSNames from the CSR if CRN is specified and valid", func() {
+				csr = _createCSR(exampleCn, exampleSan, exampleIPs)
+				spec := api.CertificateSpec{
+					CSR: csr,
+				}
+				dnsNames, err := utils.ExtractDomains(&spec)
+				Expect(dnsNames).To(Equal(append([]string{exampleCn}, append(exampleSan, "192.168.1.1", "10.0.0.1")...)))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return error if CRN is specified and not valid", func() {
+				spec := api.CertificateSpec{
+					CSR: []byte{},
+				}
+				dnsNames, err := utils.ExtractDomains(&spec)
+				Expect(dnsNames).To(BeNil())
+				Expect(err).To(MatchError("parsing CSR failed: decoding CSR failed"))
+			})
+		})
+	})
+})
+
+func _createCSR(cn string, san []string, ips []net.IP) []byte {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		DNSNames:    san,
+		IPAddresses: ips,
+	}
+	csr, _ := x509.CreateCertificateRequest(rand.Reader, template, key)
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csr,
+	})
+}

--- a/pkg/cert/utils/utils_certificate_test.go
+++ b/pkg/cert/utils/utils_certificate_test.go
@@ -17,8 +17,7 @@ import (
 
 var _ = Describe("UtilsCertificate", func() {
 	var (
-		csr []byte
-		exampleCn string
+		exampleCn  string
 		exampleSan []string
 		exampleIPs []net.IP
 	)
@@ -31,42 +30,36 @@ var _ = Describe("UtilsCertificate", func() {
 
 	Describe("ExtractCommonNameAnDNSNames", func() {
 
-		Context("Common Name (cn), Subject Alternative Name (san), and IP Addresses are set", func() {
-			It("should extract cn, san, and IP addresses", func() {
-				csr = _createCSR(exampleCn, exampleSan, exampleIPs)
-				cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(*cn).To(Equal(exampleCn))
-				Expect(san).To(ContainElements(append(exampleSan, "192.168.1.1", "10.0.0.1")))
-			})
+		It("should extract cn, san, and IP addresses if Common Name (cn), Subject Alternative Name (san), and IP Addresses are set", func() {
+			csr := _createCSR(exampleCn, exampleSan, exampleIPs)
+			cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*cn).To(Equal(exampleCn))
+			Expect(san).To(ContainElements(append(exampleSan, "192.168.1.1", "10.0.0.1")))
 		})
 
-		Context("Common Name is not set", func() {
-			It("should only return the san and IP addresses", func() {
-				csr = _createCSR("", exampleSan, exampleIPs)
-				cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cn).To(BeNil())
-				Expect(san).To(ContainElements(append(exampleSan, "192.168.1.1", "10.0.0.1")))
-			})
+		It("should only return the san and IP addresses if Common Name is not set", func() {
+			csr := _createCSR("", exampleSan, exampleIPs)
+			cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cn).To(BeNil())
+			Expect(san).To(ContainElements(append(exampleSan, "192.168.1.1", "10.0.0.1")))
 		})
 
-		Context("CSR is not parseable", func() {
-			It("should fail with an error", func() {
-				csr = []byte("invalid csr")
-				cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("parsing CSR failed: decoding CSR failed"))
-				Expect(cn).To(BeNil())
-				Expect(san).To(BeEmpty())
-			})
+		It("should fail with an error if CSR is not parseable", func() {
+			csr := []byte("invalid csr")
+			cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("parsing CSR failed: decoding CSR failed"))
+			Expect(cn).To(BeNil())
+			Expect(san).To(BeEmpty())
 		})
 	})
 
 	Describe("ExtractDomains", func() {
 		Context("CommonName or DNSNames are specified", func() {
 			It("should return an error if CSR is not nil", func() {
-				csr = _createCSR("", nil, nil)
+				csr := _createCSR("", nil, nil)
 				spec := api.CertificateSpec{
 					CommonName: &exampleCn,
 					DNSNames:   exampleSan,
@@ -104,7 +97,7 @@ var _ = Describe("UtilsCertificate", func() {
 				Expect(err).To(MatchError("the Common Name is limited to 64 characters (X.509 ASN.1 specification), but first given domain aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa has 65 characters"))
 			})
 
-			It("should return the CommonName and DNSName when both are specified", func ()  {
+			It("should return the CommonName and DNSName when both are specified", func() {
 				spec := api.CertificateSpec{
 					CommonName: &exampleCn,
 					DNSNames:   exampleSan,
@@ -126,7 +119,7 @@ var _ = Describe("UtilsCertificate", func() {
 			})
 
 			It("should extract the DNSNames from the CSR if CRN is specified and valid", func() {
-				csr = _createCSR(exampleCn, exampleSan, exampleIPs)
+				csr := _createCSR(exampleCn, exampleSan, exampleIPs)
 				spec := api.CertificateSpec{
 					CSR: csr,
 				}

--- a/pkg/cert/utils/utils_certificate_test.go
+++ b/pkg/cert/utils/utils_certificate_test.go
@@ -16,10 +16,12 @@ import (
 )
 
 var _ = Describe("UtilsCertificate", func() {
-	var csr []byte
-	var exampleCn string
-	var exampleSan []string
-	var exampleIPs []net.IP
+	var (
+		csr []byte
+		exampleCn string
+		exampleSan []string
+		exampleIPs []net.IP
+	)
 
 	BeforeEach(func() {
 		exampleCn = "example.com"

--- a/pkg/cert/utils/utils_certificate_test.go
+++ b/pkg/cert/utils/utils_certificate_test.go
@@ -29,7 +29,6 @@ var _ = Describe("UtilsCertificate", func() {
 	})
 
 	Describe("ExtractCommonNameAnDNSNames", func() {
-
 		It("should extract cn, san, and IP addresses if Common Name (cn), Subject Alternative Name (san), and IP Addresses are set", func() {
 			csr := _createCSR(exampleCn, exampleSan, exampleIPs)
 			cn, san, err := utils.ExtractCommonNameAnDNSNames(csr)
@@ -110,7 +109,6 @@ var _ = Describe("UtilsCertificate", func() {
 		})
 
 		Context("Neither CommonName nor DNSNames are specified", func() {
-
 			It("should return error if CSR is not specified either", func() {
 				spec := api.CertificateSpec{}
 				dnsNames, err := utils.ExtractDomains(&spec)

--- a/pkg/cert/utils/utils_mod.go
+++ b/pkg/cert/utils/utils_mod.go
@@ -10,19 +10,19 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources/abstract"
 )
 
-// AssureStringArray handles modification of a string array.
-func AssureStringArray(mod *abstract.ModificationState, dst *[]string, value []string) {
+// AssureStringSlice handles modification of a string slice.
+func AssureStringSlice(mod *abstract.ModificationState, dst *[]string, value []string) {
 	if value == nil {
 		value = []string{}
 	}
-	if !EqualStringArray(*dst, value) {
+	if !EqualStringSlice(*dst, value) {
 		*dst = value
 		mod.Modify(true)
 	}
 }
 
-// EqualStringArray compares string arrays.
-func EqualStringArray(a, b []string) bool {
+// EqualStringSlice compares string slices.
+func EqualStringSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/cert/utils/utils_mod.go
+++ b/pkg/cert/utils/utils_mod.go
@@ -12,6 +12,9 @@ import (
 
 // AssureStringSlice handles modification of a string slice.
 func AssureStringSlice(mod *abstract.ModificationState, dst *[]string, value []string) {
+	if mod == nil || dst == nil {
+		return
+	}
 	if value == nil {
 		value = []string{}
 	}

--- a/pkg/cert/utils/utils_mod_test.go
+++ b/pkg/cert/utils/utils_mod_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package utils_test
 
 import (

--- a/pkg/cert/utils/utils_mod_test.go
+++ b/pkg/cert/utils/utils_mod_test.go
@@ -11,21 +11,21 @@ import (
 
 var _ = Describe("UtilsMod", func() {
 
-	Describe("AssureStringSlice", func ()  {
+	Describe("AssureStringSlice", func() {
 
 		var mod *abstract.ModificationState
-		BeforeEach(func ()  {
-			mod = &abstract.ModificationState {
+		BeforeEach(func() {
+			mod = &abstract.ModificationState{
 				ModificationState: libUtils.ModificationState{
 					Modified: false,
 				},
 			}
 		})
 
-		It("should update the dst sclice with value if both slices have values", func ()  {
+		It("should update the dst sclice with value if both slices have values", func() {
 			dst := []string{"Old", "Value", "Another value"}
 			value := []string{"New", "Value"}
-			
+
 			Expect(mod.Modified).To(BeFalse())
 
 			utils.AssureStringSlice(mod, &dst, value)
@@ -35,22 +35,39 @@ var _ = Describe("UtilsMod", func() {
 		})
 
 		It("should set dst to an empty slice if value is nil", func() {
-            dst := []string{"Old", "Value"}
+			dst := []string{"Old", "Value"}
 
-            utils.AssureStringSlice(mod, &dst, nil)
+			utils.AssureStringSlice(mod, &dst, nil)
 
-            Expect(dst).To(Equal([]string{}))
-            Expect(mod.Modified).To(BeTrue())
-        })
+			Expect(dst).To(Equal([]string{}))
+			Expect(mod.Modified).To(BeTrue())
+		})
 
-		It("should not modify dst if dst and value are equal", func ()  {
+		It("should not modify dst if dst and value are equal", func() {
 			dst := []string{"Value1", "Value2"}
 			value := []string{"Value1", "Value2"}
 
-            utils.AssureStringSlice(mod, &dst, value)
+			utils.AssureStringSlice(mod, &dst, value)
 
 			Expect(dst).To(Equal(value))
-            Expect(mod.Modified).To(BeFalse())
+			Expect(mod.Modified).To(BeFalse())
+		})
+
+		It("should not modify dst if mod is nil", func() {
+			dst := []string{"Old", "Value", "Another value"}
+			value := []string{"New", "Value"}
+
+			utils.AssureStringSlice(nil, &dst, value)
+
+			Expect(dst).To(Equal([]string{"Old", "Value", "Another value"}))
+		})
+
+		It("should not modify dst if dst is nil", func() {
+			value := []string{"Value1", "Value2"}
+
+			utils.AssureStringSlice(mod, nil, value)
+
+			Expect(mod.Modified).To(BeFalse())
 		})
 
 	})
@@ -62,6 +79,10 @@ var _ = Describe("UtilsMod", func() {
 
 		It("should return false for unequal slices", func() {
 			Expect(utils.EqualStringSlice([]string{"a", "b", "c"}, []string{"a", "b", "d"})).To(BeFalse())
+		})
+
+		It("should return true for two nil slices", func() {
+			Expect(utils.EqualStringSlice(nil, nil)).To(BeTrue())
 		})
 	})
 })

--- a/pkg/cert/utils/utils_mod_test.go
+++ b/pkg/cert/utils/utils_mod_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 var _ = Describe("UtilsMod", func() {
-
 	Describe("AssureStringSlice", func() {
-
 		var mod *abstract.ModificationState
 		BeforeEach(func() {
 			mod = &abstract.ModificationState{

--- a/pkg/cert/utils/utils_mod_test.go
+++ b/pkg/cert/utils/utils_mod_test.go
@@ -1,0 +1,67 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/cert-management/pkg/cert/utils"
+	"github.com/gardener/controller-manager-library/pkg/resources/abstract"
+	libUtils "github.com/gardener/controller-manager-library/pkg/utils"
+)
+
+var _ = Describe("UtilsMod", func() {
+
+	Describe("AssureStringSlice", func ()  {
+
+		var mod *abstract.ModificationState
+		BeforeEach(func ()  {
+			mod = &abstract.ModificationState {
+				ModificationState: libUtils.ModificationState{
+					Modified: false,
+				},
+			}
+		})
+
+		It("should update the dst sclice with value if both slices have values", func ()  {
+			dst := []string{"Old", "Value", "Another value"}
+			value := []string{"New", "Value"}
+			
+			Expect(mod.Modified).To(BeFalse())
+
+			utils.AssureStringSlice(mod, &dst, value)
+
+			Expect(dst).To(Equal(value))
+			Expect(mod.Modified).To(BeTrue())
+		})
+
+		It("should set dst to an empty slice if value is nil", func() {
+            dst := []string{"Old", "Value"}
+
+            utils.AssureStringSlice(mod, &dst, nil)
+
+            Expect(dst).To(Equal([]string{}))
+            Expect(mod.Modified).To(BeTrue())
+        })
+
+		It("should not modify dst if dst and value are equal", func ()  {
+			dst := []string{"Value1", "Value2"}
+			value := []string{"Value1", "Value2"}
+
+            utils.AssureStringSlice(mod, &dst, value)
+
+			Expect(dst).To(Equal(value))
+            Expect(mod.Modified).To(BeFalse())
+		})
+
+	})
+
+	Describe("EqualStringSlice", func() {
+		It("should return true for equal slices", func() {
+			Expect(utils.EqualStringSlice([]string{"a", "b", "c"}, []string{"a", "b", "c"})).To(BeTrue())
+		})
+
+		It("should return false for unequal slices", func() {
+			Expect(utils.EqualStringSlice([]string{"a", "b", "c"}, []string{"a", "b", "d"})).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -1173,7 +1173,7 @@ func (r *certReconciler) prepareUpdateStatus(obj resources.Object, state string,
 		cn, dnsNames, _ = utils.ExtractCommonNameAnDNSNames(crt.Spec.CSR)
 	}
 	mod.AssureStringPtrPtr(&status.CommonName, cn)
-	utils.AssureStringArray(mod.ModificationState, &status.DNSNames, dnsNames)
+	utils.AssureStringSlice(mod.ModificationState, &status.DNSNames, dnsNames)
 
 	var expirationDate *string
 	notAfter, ok := resources.GetAnnotation(crt, AnnotationNotAfter)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `test-cov` make target. It targets the [test-cover.sh](https://github.com/gardener/gardener/blob/master/hack/test-cover.sh) File of the [Gardener Repository](https://github.com/gardener/gardener/).

**Which issue(s) this PR fixes**:
Fixes #
Until now there was no make target for running unit tests with coverage like in the [Gardener Repository](https://github.com/gardener/gardener/).

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
