### PR TITLE
Fix exhaustion of request quotas on concurrent certificates with same domain name

### DIFF
--- a/pkg/apis/cert/v1alpha1/state.go
+++ b/pkg/apis/cert/v1alpha1/state.go
@@ -9,6 +9,8 @@ package v1alpha1
 const (
 	// StatePending is the pending state.
 	StatePending = "Pending"
+	// StateWaiting is the waiting state.
+	StateWaiting = "Waiting"
 	// StateError is the error state.
 	StateError = "Error"
 	// StateReady is the ready state.

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -564,9 +564,9 @@ func (r *certReconciler) obtainCertificateAndPendingACME(logctx logger.LogContex
 		var notAcceptedError *notAcceptedError
 		switch {
 		case errors.As(err, &concurrentObtainError):
-			return r.delay(logctx, obj, "", err)
+			return r.delay(logctx, obj, api.StateWaiting, err)
 		case errors.As(err, &notAcceptedError):
-			return r.recheck(logctx, obj, "", err, notAcceptedError.waitTime)
+			return r.recheck(logctx, obj, api.StateWaiting, err, notAcceptedError.waitTime)
 		default:
 			return r.failed(logctx, obj, api.StateError, fmt.Errorf("preparing obtaining certificates failed: %w", err))
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
If two certificates with the same set of domain names are created at the same time, they are reconciled often and use up the certificate request quota ("request quota per day").
This is a fix to count the reconciliation only if all preconditions for the request are fulfilled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix exhaustion of request quotas on concurrent certificates with same domain name
```
