### PR TITLE
feat: Build `linux/arm64` image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,6 +29,10 @@ cert-management:
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           cert-management:
             dockerfile: 'Dockerfile'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR introduces a multi-arch build for the Docker image inspired by/based on the implementation here:
https://github.com/search?q=repo%3Agardener%2Fgardener-extension-shoot-rsyslog-relp%20arm64&type=code

**Which issue(s) this PR fixes**:

Currently, it's not possible to use `cert-management` on `arm64` machines.

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Introduce multi-arch build for `linux/arm64` images.
```
