### PR TITLE
fix: Dedupe Make test-integration target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,9 @@ test: $(GINKGO)
 	# $(GINKGO) -r ./pkg
 
 .PHONY: test-integration
-test-integration: $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
+test-integration: $(GINKGO) $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
 	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/integration/...
+	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/certman2/integration/...
 
 .PHONY: test-cov
 test-cov:
@@ -156,10 +157,6 @@ certman-dnsrecords-up: $(SKAFFOLD) $(HELM) kind-issuer-up skaffold-run-dnsrecord
 certman-dnsrecords-down:
 	@hack/kind/certman/issuer-down.sh
 	@hack/kind/certman/certman-down.sh
-
-.PHONY: test-integration
-test-integration: $(GINKGO) $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
-	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/certman2/integration/...
 
 .PHONY: test-functional-local
 test-functional-local: $(GINKGO)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind test

**What this PR does / why we need it**:

The Make target `test-integration` is duplicated due to a merge artifact.
This PR dedupes the `test-integration` target.

**Which issue(s) this PR fixes**:

Follow-up to #426

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
