### PR TITLE
chore: Add copyright profile for GoLand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 .idea/
+!.idea/copyright/
 *.sw[pq]
 tmp/
 /dev/

--- a/.idea/copyright/Gardener.xml
+++ b/.idea/copyright/Gardener.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="keyword" value="SPDX-FileCopyrightText" />
+    <option name="notice" value="SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors&#10;&#10;SPDX-License-Identifier: Apache-2.0" />
+    <option name="myName" value="Gardener" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="Gardener">
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="block" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR adds a copyright profile and related settings for IDEA-based IDEs such as GoLand.
The copyright template looks like this:
```
// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
//
// SPDX-License-Identifier: Apache-2.0
```

This is the same template used by `make add-license-headers`.

I'm unsure whether we want to add editor-specific files to the repository. Personally, I'm okay with it and I've only excluded the copyright settings from the `.gitignore`.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

What do you think?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
