### PR TITLE
ci: Unify `make format`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -49,6 +49,8 @@ cert-management:
         output_dir: binary
       check:
         image: golang:1.24
+      verify:
+        image: golang:1.24
   jobs:
     head-update:
       traits:

--- a/.ci/verify
+++ b/.ci/verify
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(dirname $0)/.."
+
+git config --global user.email "gardener@sap.com"
+git config --global user.name "Gardener CI/CD"
+
+export GOTOOLCHAIN=auto
+make verify-extended

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ generate: $(VGOPATH) $(CONTROLLER_GEN) $(MOCKGEN)
 	@GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) ./hack/generate-code
 	@CONTROLLER_MANAGER_LIB_HACK_DIR=$(CONTROLLER_MANAGER_LIB_HACK_DIR) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) CONTROLLER_GEN=$(shell realpath $(CONTROLLER_GEN)) go generate ./pkg/...
 	@./hack/copy-crds.sh
-	@go fmt ./pkg/...
+	@(MAKE) format
 
 .PHONY: generate-renovate-ignore-deps
 generate-renovate-ignore-deps:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ clean:
 	bash $(GARDENER_HACK_DIR)/clean.sh ./cmd/... ./pkg/...
 	@rm -f $(REPO_ROOT)/pkg/apis/cert/crds/*
 
+.PHONY: check-generate
+check-generate:
+	@bash $(GARDENER_HACK_DIR)/check-generate.sh $(REPO_ROOT)
+
 .PHONY: check
 check: sast-report fastcheck
 
@@ -88,6 +92,10 @@ test-integration: $(GINKGO) $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
 .PHONY: test-cov
 test-cov:
 	@bash $(GARDENER_HACK_DIR)/test-cover.sh $(shell go list ./pkg/... | grep -v -E "/pkg/client|/mock") ./cmd/...
+
+.PHONY: test-clean
+test-clean:
+	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
 .PHONY: generate
 generate: $(VGOPATH) $(CONTROLLER_GEN) $(MOCKGEN)
@@ -173,3 +181,9 @@ sast: $(GOSEC)
 .PHONY: sast-report
 sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
+
+.PHONY: verify
+verify: check format test sast
+
+.PHONY: verify-extended
+verify-extended: check-generate check format test-cov test-clean test-integration test-e2e-local sast-report

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ generate: $(VGOPATH) $(CONTROLLER_GEN) $(MOCKGEN)
 	@GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) ./hack/generate-code
 	@CONTROLLER_MANAGER_LIB_HACK_DIR=$(CONTROLLER_MANAGER_LIB_HACK_DIR) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) CONTROLLER_GEN=$(shell realpath $(CONTROLLER_GEN)) go generate ./pkg/...
 	@./hack/copy-crds.sh
-	@(MAKE) format
+	$(MAKE) format
 
 .PHONY: generate-renovate-ignore-deps
 generate-renovate-ignore-deps:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR intends to unify how `make format` works between the Cert- & DNS-management repositories.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

Related PRs:
* https://github.com/gardener/external-dns-management/pull/426
* https://github.com/gardener/gardener-extension-shoot-cert-service/pull/360
* https://github.com/gardener/gardener-extension-shoot-dns-service/pull/451

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
