### PR TITLE
docs: Document triggering a manual certificate renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Currently, the `cert-controller-manager` supports certificate authorities via:
   - [Using the cert-controller-manager](#using-the-cert-controller-manager)
     - [Usage](#usage)
   - [Renewal of Certificates](#renewal-of-certificates)
+    - [Triggering a manual Certificate renewal](#triggering-a-manual-certificate-renewal) 
   - [Revoking Certificates](#revoking-certificates)
     - [Revoking certificates with renewal](#revoking-certificates-with-renewal)
     - [Checking OCSP revocation using OpenSSL](#checking-ocsp-revocation-using-openssl)
@@ -1041,6 +1042,22 @@ For example, if [Let's Encrypt](https://letsencrypt.org/) is used as certificate
 is always valid for 90 days and will be rolled 30 days before it expires by updating the referenced `Secret`
 in the `Certificate` object.  
 The configuration can be changed with the command line parameter `--issuer.renewal-window`.
+
+### Triggering a manual Certificate renewal
+
+You can trigger a manual renewal of a `Certificate` by setting `.spec.renew` to `true`.
+The controller will then renew the certificate with the next reconciliation and remove the field.
+
+```yaml
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: Certificate
+metadata:
+  name: renew-sample
+  namespace: default
+spec:
+  commonName: cert1.mydomain.com
+  renew: true # trigger a renewal with the next reconciliation, the field will be removed
+```
 
 ## Revoking Certificates
 

--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,8 @@ spec:
   ensureRenewedAfter: null # mandatory if a manual renewal was already triggered 
 ```
 
+If the field `.spec.ensureRenewedAfter` is set and you want to trigger the renewal again, make sure to remove it (e.g. by setting the value explicitly to `null`).
+
 ## Revoking Certificates
 
 Certificates created with an `ACME` issuer can also be revoked if private key of the certificate

--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,7 @@ metadata:
 spec:
   commonName: cert1.mydomain.com
   renew: true # trigger a renewal with the next reconciliation, the field will be removed
+  ensureRenewedAfter: null # mandatory if a manual renewal was already triggered 
 ```
 
 ## Revoking Certificates


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR documents how to trigger a manual `Certificate` renewal using the `.spec.renew` field.

**Which issue(s) this PR fixes**:

_n.a._

Today, most readers would only learn about this mechanism through the `CertificateRevocation` resource which also supports the `renew` field. However, you don't need a `CertificateRevocation` to renew your `Certificate` as you can achieve the same on the resource itself.

**Special notes for your reviewer**:

/cc @MartinWeindel @LucaBernstein

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Added documentation for triggering a manual `Certificate` renewal.
```
