### PR TITLE
fix: Key algorithm and bit size in self-signed certs from CA

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -709,6 +709,10 @@ func (r *certReconciler) obtainCertificateCA(logctx logger.LogContext, obj resou
 	if duration == nil {
 		duration = ptr.To(2 * legobridge.DefaultCertDuration)
 	}
+	keyType, err := r.certificatePrivateKeyDefaults.ToKeyType(cert.Spec.PrivateKey)
+	if err != nil {
+		return r.failedStop(logctx, obj, api.StateError, err)
+	}
 	err = r.validateCertDuration(duration, CAKeyPair)
 	if err != nil {
 		return r.failedStop(logctx, obj, api.StateError, err)
@@ -742,7 +746,7 @@ func (r *certReconciler) obtainCertificateCA(logctx logger.LogContext, obj resou
 
 	input := legobridge.ObtainInput{CAKeyPair: CAKeyPair, IssuerKey: issuerKey,
 		CommonName: cert.Spec.CommonName, DNSNames: cert.Spec.DNSNames, CSR: cert.Spec.CSR,
-		Callback: callback, Renew: renew, Duration: duration}
+		Callback: callback, Renew: renew, Duration: duration, KeyType: keyType}
 
 	err = r.obtainer.Obtain(input)
 	if err != nil {

--- a/pkg/shared/legobridge/certificate.go
+++ b/pkg/shared/legobridge/certificate.go
@@ -438,6 +438,7 @@ func (o *obtainer) ObtainFromCA(input ObtainInput) error {
 			IssuerInfo:   shared.NewCAIssuerInfo(input.IssuerKey),
 			CommonName:   input.CommonName,
 			DNSNames:     input.DNSNames,
+			KeyType:      input.KeyType,
 			CSR:          input.CSR,
 			Err:          err,
 		}

--- a/test/integration/controller/issuer/certificate_test.go
+++ b/test/integration/controller/issuer/certificate_test.go
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package issuer_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Certificate controller tests", func() {
+	var (
+		testRunID     string
+		testNamespace *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		Expect(acmeDirectoryAddress).NotTo(BeEmpty())
+
+		ctxLocal := context.Background()
+
+		By("Create test Namespace")
+		testNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "certificate-",
+			},
+		}
+		Expect(testClient.Create(ctxLocal, testNamespace)).To(Succeed())
+		log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+		testRunID = testNamespace.Name
+
+		DeferCleanup(func() {
+			By("Delete test Namespace")
+			Expect(testClient.Delete(ctxLocal, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+		})
+
+		By("Start manager")
+		startManager(testRunID)
+
+		DeferCleanup(func() {
+			By("Stop manager")
+			stopManager()
+		})
+	})
+
+	Context("Self-signed certificates from CA issuer", func() {
+		var caIssuer *certv1alpha1.Issuer
+
+		BeforeEach(func() {
+			By("Create self-signed issuer")
+			selfSignedIssuer := &certv1alpha1.Issuer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testNamespace.Name,
+					GenerateName: "self-signed-issuer-",
+				},
+				Spec: certv1alpha1.IssuerSpec{
+					SelfSigned: &certv1alpha1.SelfSignedSpec{},
+				},
+			}
+			Expect(testClient.Create(ctx, selfSignedIssuer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, selfSignedIssuer)).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(selfSignedIssuer), selfSignedIssuer)).To(Succeed())
+				g.Expect(selfSignedIssuer.Status.State).To(Equal("Ready"))
+			}).Should(Succeed())
+
+			By("Create self-signed root certificate")
+			rootCertificate := &certv1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testNamespace.Name,
+					GenerateName: "root-certificate-",
+				},
+				Spec: certv1alpha1.CertificateSpec{
+					IsCA: ptr.To(true),
+					IssuerRef: &certv1alpha1.IssuerRef{
+						Namespace: selfSignedIssuer.Namespace,
+						Name:      selfSignedIssuer.Name,
+					},
+					CommonName: ptr.To("example.com"),
+				},
+			}
+			Expect(testClient.Create(ctx, rootCertificate)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, rootCertificate)).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(rootCertificate), rootCertificate)).To(Succeed())
+				g.Expect(rootCertificate.Status.State).To(Equal("Ready"))
+			}).WithTimeout(5 * time.Second).Should(Succeed())
+
+			By("Create CA issuer based on root certificate")
+			caIssuer = &certv1alpha1.Issuer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testNamespace.Name,
+					GenerateName: "ca-issuer-",
+				},
+				Spec: certv1alpha1.IssuerSpec{
+					CA: &certv1alpha1.CASpec{
+						PrivateKeySecretRef: rootCertificate.Spec.SecretRef,
+					},
+				},
+			}
+			Expect(testClient.Create(ctx, caIssuer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, caIssuer)).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(caIssuer), caIssuer)).To(Succeed())
+				g.Expect(caIssuer.Status.State).To(Equal("Ready"))
+			}).Should(Succeed())
+		})
+
+		DescribeTable("Create self-signed certificates using CA issuer",
+			func(privateKeyAlgorithm certv1alpha1.PrivateKeyAlgorithm, privateKeySize int) {
+				By("Create certificate using CA issuer")
+				certificate := &certv1alpha1.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:    testNamespace.Name,
+						GenerateName: "certificate-",
+					},
+					Spec: certv1alpha1.CertificateSpec{
+						IssuerRef: &certv1alpha1.IssuerRef{
+							Namespace: caIssuer.Namespace,
+							Name:      caIssuer.Name,
+						},
+						PrivateKey: &certv1alpha1.CertificatePrivateKey{
+							Algorithm: ptr.To(privateKeyAlgorithm),
+							Size:      ptr.To(certv1alpha1.PrivateKeySize(privateKeySize)),
+						},
+						Duration: &metav1.Duration{
+							Duration: 48 * time.Hour,
+						},
+						CommonName: ptr.To("example.com"),
+					},
+				}
+				Expect(testClient.Create(ctx, certificate)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testClient.Delete(ctx, certificate)).To(Succeed())
+				})
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(certificate), certificate)).To(Succeed())
+					g.Expect(certificate.Status.State).To(Equal("Ready"))
+				}).WithTimeout(5 * time.Second).Should(Succeed())
+
+				By("Read certificate secret")
+				secret := &corev1.Secret{}
+				Expect(testClient.Get(ctx, client.ObjectKey{
+					Namespace: certificate.Spec.SecretRef.Namespace,
+					Name:      certificate.Spec.SecretRef.Name,
+				}, secret)).To(Succeed())
+
+				By("Check that the certificate secret private key uses the expected algorithm and size")
+				privateKeyBlock, _ := pem.Decode(secret.Data[corev1.TLSPrivateKeyKey]) // tls.key
+				switch privateKeyAlgorithm {
+				case certv1alpha1.ECDSAKeyAlgorithm:
+					privateKey, err := x509.ParseECPrivateKey(privateKeyBlock.Bytes)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(privateKey).NotTo(BeNil())
+					Expect(privateKey.Curve.Params().BitSize).To(Equal(privateKeySize))
+				case certv1alpha1.RSAKeyAlgorithm:
+					privateKey, err := x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(privateKey).NotTo(BeNil())
+					Expect(privateKey.N.BitLen()).To(Equal(privateKeySize))
+				default:
+					Fail("Unsupported private key algorithm")
+				}
+			},
+			Entry("ECDSA 256", certv1alpha1.ECDSAKeyAlgorithm, 256),
+			Entry("ECDSA 384", certv1alpha1.ECDSAKeyAlgorithm, 384),
+			Entry("RSA 2048", certv1alpha1.RSAKeyAlgorithm, 2048),
+			Entry("RSA 3072", certv1alpha1.RSAKeyAlgorithm, 3072),
+			Entry("RSA 4096", certv1alpha1.RSAKeyAlgorithm, 4096),
+		)
+	})
+})

--- a/test/integration/controller/issuer/certificate_test.go
+++ b/test/integration/controller/issuer/certificate_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"time"
 
-	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,6 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 )
 
 var _ = Describe("Certificate controller tests", func() {

--- a/test/integration/controller/issuer/certificate_test.go
+++ b/test/integration/controller/issuer/certificate_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Certificate controller tests", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(rootCertificate), rootCertificate)).To(Succeed())
 				g.Expect(rootCertificate.Status.State).To(Equal("Ready"))
-			}).WithTimeout(5 * time.Second).Should(Succeed())
+			}).WithTimeout(10 * time.Second).Should(Succeed())
 
 			By("Create CA issuer based on root certificate")
 			caIssuer = &certv1alpha1.Issuer{
@@ -155,7 +155,7 @@ var _ = Describe("Certificate controller tests", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(certificate), certificate)).To(Succeed())
 					g.Expect(certificate.Status.State).To(Equal("Ready"))
-				}).WithTimeout(5 * time.Second).Should(Succeed())
+				}).WithTimeout(10 * time.Second).Should(Succeed())
 
 				By("Read certificate secret")
 				secret := &corev1.Secret{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

This PR addresses the issue described in #446.

When using anything but the default key algorithm and size, the certificate status fluctuates between `PENDING` and `READY`. The controller is provisioning the certificate repeatedly because the stored hash on the certificate resource does not match the hash calculated based on the spec. This is because the hash considers the key size of the certificate if anything but the default is used. Currently, the code for creating certificates from a CA issuer does not propagate the specified key type and ends up using the default algorithm and size.

**Changes in this PR:**
* Propagate the key type through `ObtainInput` and `ObtainOutput` of the CA certificate flow
* Use the key type to specify the correct `PublicKeyAlgorithm` and `PublicKey` in the `CertificateRequest` of the CA certificate flow
* Cover the private and public key handling code with a unit test
* Add a regression integration test for creating self-signed certificates from a CA issuer using all supported variants:
  * **ECDSA:** 256, 384
  * **RSA:** 2048, 3072, 4096

**Which issue(s) this PR fixes**:

Fixes #446

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed key algorithm and bit size in self-signed certificates from a CA issuer.
```
