### PR TITLE
fix: ClusterRole needs dnsrecord permissions when issuerUseDnsrecords is true

### DIFF
--- a/charts/cert-management/templates/clusterrole.yaml
+++ b/charts/cert-management/templates/clusterrole.yaml
@@ -95,7 +95,7 @@ rules:
   - update
   - create
   - watch
-{{- if .Values.configuration.useDnsrecords }}
+{{- if or .Values.configuration.useDnsrecords .Values.configuration.issuerUseDnsrecords }}
 - apiGroups:
   - extensions.gardener.cloud
   resources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Setting only `issuerUseDnsrecords: true` in the values of the Helm chart, leads to a broken deployment, where the cert-controller-manager wants to use `DnsRecords` but does not have permission to access the resource. This PR updates the Helm chart to also equip the `ClusterRole` with the correct permissions in this case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix: ClusterRole needs dnsrecord permissions when issuerUseDnsrecords is true
```
