### PR TITLE
Forbid privilege escalations for component containers

### DIFF
--- a/charts/cert-management/templates/deployment.yaml
+++ b/charts/cert-management/templates/deployment.yaml
@@ -483,6 +483,8 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
         {{- if .Values.configuration.caCertificates }}
         volumeMounts:
         - name: ca-certificates


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR sets the `securityContext.allowPrivilegeEscalation` field to `false` for every container, which does not have `securityContext.Privileged` set to `true` or one of `CAP_SYS_ADMIN/SYS_ADMIN` capabilities added.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#11139

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Containers, which do not require privilege escalations, now forbid privilege escalations explicitly.
```
