### PR TITLE
ci: Run integration tests in one command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,7 @@ test: $(GINKGO)
 
 .PHONY: test-integration
 test-integration: $(GINKGO) $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
-	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/integration/...
-	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/certman2/integration/...
+	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/integration/... ./test/certman2/integration/...
 
 .PHONY: test-cov
 test-cov:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind test

**What this PR does / why we need it**:

Currently, only the integration tests of `certman2` are visible in Prow and the Testgrid:
https://testgrid.k8s.io/cert-management#ci-cert-management-integration

This is due to the integration test suites of the legacy and new code line being run sequentially through two commands:
https://github.com/gardener/cert-management/blob/a01bb4e6acafc99206c977874ab1de06652e78b7/Makefile#L86-L87

The `test-integration.sh` is implemented to (over)write the `junit.xml` artifact file, hence only the latter test results are visible.

This PR runs both integration tests together in one command, which results in a single `junit.xml` containing all results.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
