### PR TITLE
feat: Add `IssuanceDate` to `Certificate` status

### DIFF
--- a/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
@@ -35,6 +35,11 @@ spec:
       jsonPath: .status.state
       name: STATUS
       type: string
+    - description: Issuance date (not valid before this date)
+      jsonPath: .status.issuanceDate
+      name: ISSUANCE_DATE
+      priority: 500
+      type: string
     - description: Expiration date (not valid anymore after this date)
       jsonPath: .status.expirationDate
       name: EXPIRATION_DATE
@@ -357,6 +362,9 @@ spec:
                 type: array
               expirationDate:
                 description: ExpirationDate shows the notAfter validity date.
+                type: string
+              issuanceDate:
+                description: IssuanceDate shows the notBefore validity date.
                 type: string
               issuerRef:
                 description: IssuerRef is the used issuer.

--- a/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
+++ b/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
@@ -29,6 +29,11 @@ spec:
       jsonPath: .status.state
       name: STATUS
       type: string
+    - description: Issuance date (not valid before this date)
+      jsonPath: .status.issuanceDate
+      name: ISSUANCE_DATE
+      priority: 500
+      type: string
     - description: Expiration date (not valid anymore after this date)
       jsonPath: .status.expirationDate
       name: EXPIRATION_DATE
@@ -351,6 +356,9 @@ spec:
                 type: array
               expirationDate:
                 description: ExpirationDate shows the notAfter validity date.
+                type: string
+              issuanceDate:
+                description: IssuanceDate shows the notBefore validity date.
                 type: string
               issuerRef:
                 description: IssuerRef is the used issuer.

--- a/pkg/apis/cert/crds/zz_generated_crds.go
+++ b/pkg/apis/cert/crds/zz_generated_crds.go
@@ -333,6 +333,11 @@ spec:
       jsonPath: .status.state
       name: STATUS
       type: string
+    - description: Issuance date (not valid before this date)
+      jsonPath: .status.issuanceDate
+      name: ISSUANCE_DATE
+      priority: 500
+      type: string
     - description: Expiration date (not valid anymore after this date)
       jsonPath: .status.expirationDate
       name: EXPIRATION_DATE
@@ -655,6 +660,9 @@ spec:
                 type: array
               expirationDate:
                 description: ExpirationDate shows the notAfter validity date.
+                type: string
+              issuanceDate:
+                description: IssuanceDate shows the notBefore validity date.
                 type: string
               issuerRef:
                 description: IssuerRef is the used issuer.

--- a/pkg/apis/cert/v1alpha1/types.go
+++ b/pkg/apis/cert/v1alpha1/types.go
@@ -30,6 +30,7 @@ type CertificateList struct {
 // +kubebuilder:printcolumn:name=COMMON NAME,description="Subject domain name of certificate",JSONPath=".status.commonName",type=string
 // +kubebuilder:printcolumn:name=ISSUER,description="Issuer name",JSONPath=".status.issuerRef.name",type=string
 // +kubebuilder:printcolumn:name=STATUS,JSONPath=".status.state",type=string,description="Status of registration"
+// +kubebuilder:printcolumn:name=ISSUANCE_DATE,JSONPath=".status.issuanceDate",priority=500,type=string,description="Issuance date (not valid before this date)"
 // +kubebuilder:printcolumn:name=EXPIRATION_DATE,JSONPath=".status.expirationDate",priority=500,type=string,description="Expiration date (not valid anymore after this date)"
 // +kubebuilder:printcolumn:name=DNS_NAMES,JSONPath=".status.dnsNames",priority=2000,type=string,description="Domains names in subject alternative names"
 // +kubebuilder:printcolumn:name=AGE,JSONPath=".metadata.creationTimestamp",type=date,description="object creation timestamp"
@@ -180,6 +181,9 @@ type CertificateStatus struct {
 	// IssuerRef is the used issuer.
 	// +optional
 	IssuerRef *QualifiedIssuerRef `json:"issuerRef,omitempty"`
+	// IssuanceDate shows the notBefore validity date.
+	// +optional
+	IssuanceDate *string `json:"issuanceDate,omitempty"`
 	// ExpirationDate shows the notAfter validity date.
 	// +optional
 	ExpirationDate *string `json:"expirationDate,omitempty"`

--- a/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
@@ -503,6 +503,11 @@ func (in *CertificateStatus) DeepCopyInto(out *CertificateStatus) {
 		*out = new(QualifiedIssuerRef)
 		**out = **in
 	}
+	if in.IssuanceDate != nil {
+		in, out := &in.IssuanceDate, &out.IssuanceDate
+		*out = new(string)
+		**out = **in
+	}
 	if in.ExpirationDate != nil {
 		in, out := &in.ExpirationDate, &out.ExpirationDate
 		*out = new(string)

--- a/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
+++ b/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
@@ -29,6 +29,11 @@ spec:
       jsonPath: .status.state
       name: STATUS
       type: string
+    - description: Issuance date (not valid before this date)
+      jsonPath: .status.issuanceDate
+      name: ISSUANCE_DATE
+      priority: 500
+      type: string
     - description: Expiration date (not valid anymore after this date)
       jsonPath: .status.expirationDate
       name: EXPIRATION_DATE
@@ -351,6 +356,9 @@ spec:
                 type: array
               expirationDate:
                 description: ExpirationDate shows the notAfter validity date.
+                type: string
+              issuanceDate:
+                description: IssuanceDate shows the notBefore validity date.
                 type: string
               issuerRef:
                 description: IssuerRef is the used issuer.

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -1053,7 +1053,7 @@ func (r *certReconciler) findSecretByHashLabel(namespace string, spec *api.Certi
 		}
 	}
 	if best == nil {
-		return nil, fmt.Errorf("could not determine a best match in the certificate secrets with the hash: %s", specHash)
+		return nil, nil
 	}
 	ref := &corev1.SecretReference{Namespace: best.GetNamespace(), Name: best.GetName()}
 	return &secretLookupResult{ref, specHash, &notBefore, &bestNotAfter}, nil

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -485,7 +485,11 @@ func (r *certReconciler) obtainCertificateAndPendingACME(logctx logger.LogContex
 		return r.failedStop(logctx, obj, api.StateError, err)
 	}
 
-	if secret, _ := r.findSecretByHashLabel(cert.Namespace, &cert.Spec); secret != nil {
+	secret, err := r.findSecretByHashLabel(cert.Namespace, &cert.Spec)
+	if err != nil {
+		return r.failedStop(logctx, obj, api.StateError, err)
+	}
+	if secret != nil {
 		// reuse found certificate
 		issuerInfo := shared.NewACMEIssuerInfo(issuerKey)
 		secretRef, err := r.copySecretIfNeeded(logctx, issuerInfo, cert.ObjectMeta, secret.ref, secret.specHash, &cert.Spec)
@@ -658,7 +662,11 @@ func (r *certReconciler) obtainCertificateSelfSigned(logctx logger.LogContext, o
 		return r.failedStop(logctx, obj, api.StateError, err)
 	}
 
-	if secret, _ := r.findSecretByHashLabel(cert.Namespace, &cert.Spec); secret != nil {
+	secret, err := r.findSecretByHashLabel(cert.Namespace, &cert.Spec)
+	if err != nil {
+		return r.failedStop(logctx, obj, api.StateError, err)
+	}
+	if secret != nil {
 		// reuse found certificate
 		issuerInfo := shared.NewSelfSignedIssuerInfo(issuerKey)
 		secretRef, err := r.copySecretIfNeeded(logctx, issuerInfo, cert.ObjectMeta, secret.ref, secret.specHash, &cert.Spec)
@@ -737,7 +745,11 @@ func (r *certReconciler) obtainCertificateCA(logctx logger.LogContext, obj resou
 		return r.failedStop(logctx, obj, api.StateError, err)
 	}
 
-	if secret, _ := r.findSecretByHashLabel(cert.Namespace, &cert.Spec); secret != nil {
+	secret, err := r.findSecretByHashLabel(cert.Namespace, &cert.Spec)
+	if err != nil {
+		return r.failedStop(logctx, obj, api.StateError, err)
+	}
+	if secret != nil {
 		// reuse found certificate
 		issuerInfo := shared.NewCAIssuerInfo(issuerKey)
 		secretRef, err := r.copySecretIfNeeded(logctx, issuerInfo, cert.ObjectMeta, secret.ref, secret.specHash, &cert.Spec)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind api-change
/kind task

**What this PR does / why we need it**:

This PR adds a `cert.gardener.cloud/not-before` annotation and a new field `issuanceDate` to the `Certificate` status.
The change is analogous to the `cert.gardener.cloud/not-after` annotation and `expirationDate` field.

As the name indicates, the annotation and field capture the `NotBefore` field of an [x509.Certificate](https://github.com/golang/go/blob/1cc624fd6265abe16de78e9cd84272435156aa72/src/crypto/x509/x509.go#L703).

Example output of `kubectl get -owide`:
```terminal
k get cert cert-selfsigned -n default -owide
NAME              COMMON NAME        ISSUER              STATUS   ISSUANCE_DATE          EXPIRATION_DATE        DNS_NAMES   AGE
cert-selfsigned   ca1.mydomain.com   issuer-selfsigned   Ready    2025-05-02T09:35:17Z   2025-07-31T09:35:17Z               121m
```

<details>
<summary>
Example YAML output

`k get cert cert-selfsigned -n default -oyaml`

</summary>

```terminal
apiVersion: cert.gardener.cloud/v1alpha1
kind: Certificate
metadata:
  annotations:
    cert.gardener.cloud/not-after: "2025-07-31T09:35:17Z"
    cert.gardener.cloud/not-before: "2025-05-02T09:35:17Z"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cert.gardener.cloud/v1alpha1","kind":"Certificate","metadata":{"annotations":{},"name":"cert-selfsigned","namespace":"default"},"spec":{"commonName":"ca1.mydomain.com","isCA":true,"issuerRef":{"name":"issuer-selfsigned","namespace":"default"}}}
  creationTimestamp: "2025-05-02T09:35:17Z"
  generation: 2
  labels:
    cert.gardener.cloud/hash: ee276e3074c86e90723ba41ebd22069741948eb0e409bbb1ce52048f
  name: cert-selfsigned
  namespace: default
  resourceVersion: "4451"
  uid: 40a049f8-1852-45c8-b29d-79f4cda80e9e
spec:
  commonName: ca1.mydomain.com
  isCA: true
  issuerRef:
    name: issuer-selfsigned
    namespace: default
  secretRef:
    name: cert-selfsigned-s6nsw
    namespace: default
status:
  commonName: ca1.mydomain.com
  conditions:
  - lastTransitionTime: "2025-05-02T09:35:17Z"
    message: ""
    observedGeneration: 2
    reason: Ready
    status: "True"
    type: Ready
  expirationDate: "2025-07-31T09:35:17Z"
  issuanceDate: "2025-05-02T09:35:17Z" # <-- New!
  issuerRef:
    cluster: default
    name: issuer-selfsigned
    namespace: default
  message: certificate (SN 1) valid from 2025-05-02 09:35:17 +0000 UTC to 2025-07-31
    09:35:17 +0000 UTC
  observedGeneration: 2
  state: Ready
```

</details>

**Which issue(s) this PR fixes**:

Fixes #454

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added `cert.gardener.cloud/not-before` annotation and `IssuanceDate` field to `Certificate`.
```
