### PR TITLE
refactor: Rename `secret` to `secretRec`

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -1171,20 +1171,20 @@ func (r *certReconciler) updateKeystoresIfSpecChanged(logctx logger.LogContext, 
 	return nil
 }
 
-func (r *certReconciler) updateSecretRefAndSucceeded(logctx logger.LogContext, obj resources.Object, secret *secretRecord) reconcile.Status {
+func (r *certReconciler) updateSecretRefAndSucceeded(logctx logger.LogContext, obj resources.Object, secretRec *secretRecord) reconcile.Status {
 	crt := obj.Data().(*api.Certificate)
-	crt.Spec.SecretRef = secret.ref
+	crt.Spec.SecretRef = secretRec.ref
 	if crt.Labels == nil {
 		crt.Labels = map[string]string{}
 	}
-	crt.Labels[LabelCertificateNewHashKey] = secret.specHash
-	if secret.notBefore != nil {
-		resources.SetAnnotation(crt, AnnotationNotBefore, secret.notBefore.Format(time.RFC3339))
+	crt.Labels[LabelCertificateNewHashKey] = secretRec.specHash
+	if secretRec.notBefore != nil {
+		resources.SetAnnotation(crt, AnnotationNotBefore, secretRec.notBefore.Format(time.RFC3339))
 	} else {
 		resources.RemoveAnnotation(crt, AnnotationNotBefore)
 	}
-	if secret.notAfter != nil {
-		resources.SetAnnotation(crt, AnnotationNotAfter, secret.notAfter.Format(time.RFC3339))
+	if secretRec.notAfter != nil {
+		resources.SetAnnotation(crt, AnnotationNotAfter, secretRec.notAfter.Format(time.RFC3339))
 	} else {
 		resources.RemoveAnnotation(crt, AnnotationNotAfter)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

Rename function parameter `secret` to `secretRec`.

**Which issue(s) this PR fixes**:

Follow-up to: https://github.com/gardener/cert-management/pull/489#discussion_r2073026788

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
