### PR TITLE
chore: Enforce import restrictions through import-boss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,12 @@ clean:
 check-generate:
 	@bash $(GARDENER_HACK_DIR)/check-generate.sh $(REPO_ROOT)
 
+.PHONY: check-imports
+check-imports: $(IMPORT_BOSS)
+	$(IMPORT_BOSS) ./cmd/... ./pkg/... ./test/...
+
 .PHONY: check
-check: format $(GOIMPORTS) $(GOLANGCI_LINT) $(GO_ADD_LICENSE)
+check: format check-imports $(GOIMPORTS) $(GOLANGCI_LINT) $(GO_ADD_LICENSE)
 	@TOOLS_BIN_DIR="$(TOOLS_BIN_DIR)" bash $(CONTROLLER_MANAGER_LIB_HACK_DIR)/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/...
 	@bash $(GARDENER_HACK_DIR)/check-license-header.sh
 	@echo "Running go vet..."

--- a/cmd/cert-controller-manager/.import-restrictions
+++ b/cmd/cert-controller-manager/.import-restrictions
@@ -1,0 +1,6 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/cert-management/pkg/certman2

--- a/cmd/certman2/.import-restrictions
+++ b/cmd/certman2/.import-restrictions
@@ -1,0 +1,10 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - github.com/gardener/cert-management/cmd/certman2
+      - github.com/gardener/cert-management/pkg/apis
+      - github.com/gardener/cert-management/pkg/certman2
+      - github.com/gardener/cert-management/pkg/shared
+  - selectorRegexp: github[.]com/gardener/controller-manager-library
+    forbiddenPrefixes:
+      - ''

--- a/pkg/apis/.import-restrictions
+++ b/pkg/apis/.import-restrictions
@@ -1,0 +1,10 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/cert-management
+# TODO(marc1404): controller-manager-library references should be removed
+#  - selectorRegexp: github[.]com/gardener/controller-manager-library
+#    forbiddenPrefixes:
+#      - ''

--- a/pkg/cert/.import-restrictions
+++ b/pkg/cert/.import-restrictions
@@ -1,0 +1,6 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/cert-management/pkg/certman2

--- a/pkg/certman2/.import-restrictions
+++ b/pkg/certman2/.import-restrictions
@@ -1,0 +1,9 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - github.com/gardener/cert-management/pkg/apis
+      - github.com/gardener/cert-management/pkg/certman2
+      - github.com/gardener/cert-management/pkg/shared
+  - selectorRegexp: github[.]com/gardener/controller-manager-library
+    forbiddenPrefixes:
+      - ''

--- a/pkg/client/.import-restrictions
+++ b/pkg/client/.import-restrictions
@@ -1,0 +1,6 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/cert-management/pkg/certman2

--- a/pkg/controller/.import-restrictions
+++ b/pkg/controller/.import-restrictions
@@ -1,0 +1,6 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/cert-management/pkg/certman2

--- a/pkg/shared/.import-restrictions
+++ b/pkg/shared/.import-restrictions
@@ -1,0 +1,8 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - github.com/gardener/cert-management/pkg/apis
+      - github.com/gardener/cert-management/pkg/shared
+  - selectorRegexp: github[.]com/gardener/controller-manager-library
+    forbiddenPrefixes:
+      - ''

--- a/test/certman2/.import-restrictions
+++ b/test/certman2/.import-restrictions
@@ -1,0 +1,9 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - github.com/gardener/cert-management/pkg/apis
+      - github.com/gardener/cert-management/pkg/certman2
+      - github.com/gardener/cert-management/pkg/shared
+  - selectorRegexp: github[.]com/gardener/controller-manager-library
+    forbiddenPrefixes:
+      - ''

--- a/test/functional/.import-restrictions
+++ b/test/functional/.import-restrictions
@@ -1,0 +1,6 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/cert-management/pkg/certman2

--- a/test/integration/.import-restrictions
+++ b/test/integration/.import-restrictions
@@ -1,0 +1,6 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/cert-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/cert-management/pkg/certman2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/kind task

**What this PR does / why we need it**:

This PR:
- Adds a new Make target `check-imports` that runs [import-boss](https://pkg.go.dev/k8s.io/gengo/examples/import-boss) to enforce rules set by `.import-restrictions` files.
  - It's integrated into Make `check`.
- It adds `.import-restrictions` to top-level folders in `cmd`, `pkg`, and `test`

The main goal is to prevent cross-imports from `certman2` to the legacy code and vice versa.

**Which issue(s) this PR fixes**:
Fixes #476

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
