### PR TITLE
docs: Document correct minimum duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ spec:
 Create a certificate ([examples/30-cert-selfsigned.yaml](./examples/30-cert-selfsigned.yaml)).
 Please note that `spec.isCA` must be set to `true` to create a self-signed certificate. The duration (life-time) of the certificate
 as well as the private key algorithm and key size may be specified. Duration value must be in units accepted by Go `time.ParseDuration`
-([see here](https://golang.org/pkg/time/#ParseDurationThe)), and it must be greater than 720h (30 days).
+([see here](https://golang.org/pkg/time/#ParseDurationThe)), and it must be at least 1440h (60 days) with the default renewal window of 30 days.
 ```yaml
 apiVersion: cert.gardener.cloud/v1alpha1
 kind: Certificate
@@ -295,8 +295,8 @@ metadata:
 spec:
   commonName: cert1.mydomain.com
   isCA: true
-  # optional: default is 90 days (2160h). Must be greater 30 days (720h)
-  # duration: 720h1m
+  # optional: default is 90 days (2160h). Must be at least 60 days (1440h) with the default renewal window of 30 days.
+  # duration: 1440h
   # optional defaults to RSA 2048
   #privateKey:
   #  algorithm: ECDSA

--- a/examples/30-cert-selfsigned.yaml
+++ b/examples/30-cert-selfsigned.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   commonName: ca1.mydomain.com
   isCA: true
-  # optional: default is 90 days (2160h). Must be greater 2*30 days (1440h)
-  # duration: 1441h
+  # optional: default is 90 days (2160h). Must be at least 2*30 days (1440h) with the default renewal window of 30 days.
+  # duration: 1440h
   # optional defaults to RSA 2048
   # privateKey:
   #   algorithm: ECDSA

--- a/pkg/controller/issuer/controller.go
+++ b/pkg/controller/issuer/controller.go
@@ -40,7 +40,7 @@ func init() {
 		DefaultedDurationOption(core.OptRenewalWindow, 30*24*time.Hour, "certificate is renewed if its validity period is shorter").
 		DefaultedDurationOption(core.OptRenewalOverdueWindow, 25*24*time.Hour, "certificate is counted as 'renewal overdue' if its validity period is shorter (metrics cert_management_overdue_renewal_certificates)").
 		DefaultedStringOption(core.OptPrecheckNameservers, "8.8.8.8:53,8.8.4.4:53",
-			"Default DNS nameservers used for checking DNS propagation. If explicity set empty, it is tried to read them from /etc/resolv.conf").
+			"Default DNS nameservers used for checking DNS propagation. If explicitly set empty, it is tried to read them from /etc/resolv.conf").
 		DefaultedDurationOption(core.OptPrecheckAdditionalWait, 10*time.Second, "additional wait time after DNS propagation check").
 		DefaultedDurationOption(core.OptPropagationTimeout, 120*time.Second, "propagation timeout for DNS challenge").
 		DefaultedIntOption(core.OptDefaultRequestsPerDayQuota, 10000,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

Currently, the documentation specifies that the minimum duration of a `Certificate` must be greater than `720h` or `1440h`. Neither is correct. The minimum duration is **at least** twice the configured renewal window (30 days by default):
https://github.com/gardener/cert-management/blob/4e33a067612a272bd2b8d9668e1bbe9a404d102d/pkg/controller/issuer/certificate/reconciler.go#L842

That means the minimum duration of a `Certificate` with a default renewal window of 30 days is:
`2 * 30d = 1440h`

**Which issue(s) this PR fixes**:

Relates to: https://github.com/gardener/cert-management/issues/492

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Documented the correct minimum duration of `Certificate`s assuming the default renewal window of 30 days.
```
