### PR TITLE
docs: Reformulate minimum `Certificate` duration description

### DIFF
--- a/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
@@ -100,7 +100,7 @@ spec:
                   ACME issuer may choose to ignore the requested duration, just like any other
                   requested attribute.
                   If unset, this defaults to 90 days (2160h).
-                  Must be greater than twice of the renewal window
+                  Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               ensureRenewedAfter:

--- a/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
+++ b/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
@@ -94,7 +94,7 @@ spec:
                   ACME issuer may choose to ignore the requested duration, just like any other
                   requested attribute.
                   If unset, this defaults to 90 days (2160h).
-                  Must be greater than twice of the renewal window
+                  Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               ensureRenewedAfter:

--- a/pkg/apis/cert/crds/zz_generated_crds.go
+++ b/pkg/apis/cert/crds/zz_generated_crds.go
@@ -398,7 +398,7 @@ spec:
                   ACME issuer may choose to ignore the requested duration, just like any other
                   requested attribute.
                   If unset, this defaults to 90 days (2160h).
-                  Must be greater than twice of the renewal window
+                  Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               ensureRenewedAfter:

--- a/pkg/apis/cert/v1alpha1/types.go
+++ b/pkg/apis/cert/v1alpha1/types.go
@@ -95,7 +95,7 @@ type CertificateSpec struct {
 	// ACME issuer may choose to ignore the requested duration, just like any other
 	// requested attribute.
 	// If unset, this defaults to 90 days (2160h).
-	// Must be greater than twice of the renewal window
+	// Must be at least twice the renewal window.
 	// Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
 	// +optional
 	Duration *metav1.Duration `json:"duration,omitempty"`

--- a/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
+++ b/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
@@ -94,7 +94,7 @@ spec:
                   ACME issuer may choose to ignore the requested duration, just like any other
                   requested attribute.
                   If unset, this defaults to 90 days (2160h).
-                  Must be greater than twice of the renewal window
+                  Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               ensureRenewedAfter:

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -839,7 +839,7 @@ func (r *certReconciler) getDuration(cert *api.Certificate) (*time.Duration, err
 	}
 	duration := cert.Spec.Duration.Duration
 	if duration < 2*r.renewalWindow {
-		return nil, fmt.Errorf("certificate duration must be greater than %v", 2*r.renewalWindow)
+		return nil, fmt.Errorf("certificate duration must be at least %v", 2*r.renewalWindow)
 	}
 	return ptr.To(duration), nil
 }

--- a/test/integration/controller/issuer/issuer_test.go
+++ b/test/integration/controller/issuer/issuer_test.go
@@ -373,7 +373,7 @@ var _ = Describe("Issuer controller tests", func() {
 				return certificate.Status
 			}).Should(MatchFields(IgnoreExtras, Fields{
 				"State":   Equal("Error"),
-				"Message": PointTo(ContainSubstring("certificate duration must be greater than 48h0m0s")),
+				"Message": PointTo(ContainSubstring("certificate duration must be at least 48h0m0s")),
 			}))
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

I forgot to adapt the `Certificate.spec.Duration` field description as well as the error message that the certificate reconciler shows for the minimum duration.

**Which issue(s) this PR fixes**:
Follow-up to: #495 

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
