### PR TITLE
Support `cert.gardener.cloud/class` annotation for `issuers`

### DIFF
--- a/examples/20-issuer-ca.yaml
+++ b/examples/20-issuer-ca.yaml
@@ -16,6 +16,9 @@ kind: Issuer
 metadata:
   name: issuer-ca
   namespace: default
+  annotations:
+    # class annotation only needed if cert-controller-manager is started with --cert-class=myclass
+    #cert.gardener.cloud/class: myclass
 spec:
   ca:
     privateKeySecretRef:

--- a/examples/20-issuer-productive.yaml
+++ b/examples/20-issuer-productive.yaml
@@ -7,6 +7,9 @@ kind: Issuer
 metadata:
   name: issuer-prod
   namespace: default
+  annotations:
+  # class annotation only needed if cert-controller-manager is started with --cert-class=myclass
+  #cert.gardener.cloud/class: myclass
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory

--- a/examples/20-issuer-staging.yaml
+++ b/examples/20-issuer-staging.yaml
@@ -7,6 +7,9 @@ kind: Issuer
 metadata:
   name: issuer-staging
   namespace: default
+  annotations:
+  # class annotation only needed if cert-controller-manager is started with --cert-class=myclass
+  #cert.gardener.cloud/class: myclass
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory

--- a/pkg/controller/issuer/controller.go
+++ b/pkg/controller/issuer/controller.go
@@ -36,7 +36,7 @@ func init() {
 		BoolOption(core.OptUseDNSRecords, "if true, DNSRecords (using Gardener Provider extensions) are created instead of DNSEntries").
 		BoolOption(core.OptCascadeDelete, "If true, certificate secrets are deleted if dependent resources (certificate, ingress) are deleted").
 		BoolOption(core.OptACMEDeactivateAuthorizations, "if true authorizations are always deactivated after each ACME certificate request").
-		StringOption(source.OptClass, "Identifier used to differentiate responsible controllers for entries").
+		StringOption(source.OptClass, "Identifier used to differentiate responsible controllers for certificates and issuers").
 		DefaultedDurationOption(core.OptRenewalWindow, 30*24*time.Hour, "certificate is renewed if its validity period is shorter").
 		DefaultedDurationOption(core.OptRenewalOverdueWindow, 25*24*time.Hour, "certificate is counted as 'renewal overdue' if its validity period is shorter (metrics cert_management_overdue_renewal_certificates)").
 		DefaultedStringOption(core.OptPrecheckNameservers, "8.8.8.8:53,8.8.4.4:53",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The annotation `cert.gardener.cloud/class` is now taken into account not only for `Certificate` and `CertificateRevocations`, but also for `Issuers`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support `cert.gardener.cloud/class` annotation for `issuers`
```
