### PR TITLE
feat: Add SAN fields in Certificate spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently, the `cert-controller-manager` supports certificate authorities via:
     - [Specifying private key algorithm and size](#specifying-private-key-algorithm-and-size)
     - [Using a certificate signing request (CSR)](#using-a-certificate-signing-request-csr)
     - [Creating JKS or PKCS#12 keystores](#creating-jks-or-pkcs12-keystores)
+    - [Subject Alternative Names (SANs)](#subject-alternative-names-sans)
   - [Requesting a Certificate for Ingress](#requesting-a-certificate-for-ingress)
     - [Process](#process)
   - [Requesting a Certificate for Service](#requesting-a-certificate-for-service)
@@ -518,6 +519,40 @@ spec:
       passwordSecretRef:
         secretName: keystore-secret
         key: password  
+```
+
+### Subject Alternative Names (SANs)
+
+> [!NOTE]  
+> [ACME](https://datatracker.ietf.org/doc/html/rfc8555/) providers such as [Let's Encrypt](https://letsencrypt.org/) typically only support DNS names as SANs.
+> Avoid specifying email addresses, IP addresses, or URIs as SANs when using an ACME `Issuer`.
+> You can use all SANs with a self-signed `Issuer` or CA `Issuer`.
+
+You can **specify subject alternative names (SANs)** in the `Certificate` spec or by using a [Certificate Signing Request (CSR)](#using-a-certificate-signing-request-csr).
+The supported SANs are:
+* DNS names – `.spec.dnsNames`
+* Email addresses – `.spec.emailAddresses`
+* IP addresses – `.spec.ipAddresses`
+* URIs – `.spec.uris`
+
+An example of a `Certificate` with SANs is shown below:
+
+```yaml
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: Certificate
+metadata:
+  name: cert-with-sans
+  namespace: default
+spec:
+  commonName: foo.example.com
+  dnsNames:
+    - bar.example.com
+  emailAddresses:
+    - foo@example.com
+  ipAddresses:
+    - 1.1.1.1
+  uris:
+    - spiffe://example.com/foo 
 ```
 
 ## Requesting a Certificate for Ingress

--- a/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
@@ -103,6 +103,12 @@ spec:
                   Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
+              emailAddresses:
+                description: EmailAddresses are the optional requested email subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               ensureRenewedAfter:
                 description: EnsureRenewedAfter specifies a time stamp in the past.
                   Renewing is only triggered if certificate notBefore date is before
@@ -114,6 +120,12 @@ spec:
                   is used if CNAME record for DNS01 challange domain `_acme-challenge.<domain>`
                   is set.
                 type: boolean
+              ipAddresses:
+                description: IPAddresses are the optional requested IP address subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               isCA:
                 description: |-
                   IsCA value is used to set the `isCA` field on the certificate request.
@@ -268,6 +280,12 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              uris:
+                description: URIs are the optional requested URI subject alternative
+                  names.
+                items:
+                  type: string
+                type: array
             type: object
           status:
             description: CertificateStatus is the status of the certificate request.

--- a/examples/30-cert-ca.yaml
+++ b/examples/30-cert-ca.yaml
@@ -11,6 +11,15 @@ spec:
   commonName: cert1.mydomain.com
   dnsNames:
   - cert1.my-other-domain.com
+  # optional: list of email addresses to be included in the certificate as subject alternative names (SANs).
+  # emailAddresses:
+  #   - foo@example.com
+  # optional: list of IP addresses to be included in the certificate as subject alternative names (SANs).
+  # ipAddresses:
+  #   - 1.1.1.1
+  # optional: list of URIs to be included in the certificate as subject alternative names (SANs).
+  # uris:
+  #   - spiffe://example.com/foo
   # if issuer is not specified, the default issuer is used
   issuerRef:
     name: issuer-ca

--- a/examples/30-cert-selfsigned.yaml
+++ b/examples/30-cert-selfsigned.yaml
@@ -12,6 +12,15 @@ spec:
   # privateKey:
   #   algorithm: ECDSA
   #   size: 384
+  # optional: list of email addresses to be included in the certificate as subject alternative names (SANs).
+  # emailAddresses:
+  #   - foo@example.com
+  # optional: list of IP addresses to be included in the certificate as subject alternative names (SANs).
+  # ipAddresses:
+  #   - 1.1.1.1
+  # optional: list of URIs to be included in the certificate as subject alternative names (SANs).
+  # uris:
+  #   - spiffe://example.com/foo
   # CSR can also be specified
   # csr: ...
   issuerRef:

--- a/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
+++ b/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
@@ -97,6 +97,12 @@ spec:
                   Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
+              emailAddresses:
+                description: EmailAddresses are the optional requested email subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               ensureRenewedAfter:
                 description: EnsureRenewedAfter specifies a time stamp in the past.
                   Renewing is only triggered if certificate notBefore date is before
@@ -108,6 +114,12 @@ spec:
                   is used if CNAME record for DNS01 challange domain `_acme-challenge.<domain>`
                   is set.
                 type: boolean
+              ipAddresses:
+                description: IPAddresses are the optional requested IP address subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               isCA:
                 description: |-
                   IsCA value is used to set the `isCA` field on the certificate request.
@@ -262,6 +274,12 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              uris:
+                description: URIs are the optional requested URI subject alternative
+                  names.
+                items:
+                  type: string
+                type: array
             type: object
           status:
             description: CertificateStatus is the status of the certificate request.

--- a/pkg/apis/cert/crds/zz_generated_crds.go
+++ b/pkg/apis/cert/crds/zz_generated_crds.go
@@ -401,6 +401,12 @@ spec:
                   Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
+              emailAddresses:
+                description: EmailAddresses are the optional requested email subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               ensureRenewedAfter:
                 description: EnsureRenewedAfter specifies a time stamp in the past.
                   Renewing is only triggered if certificate notBefore date is before
@@ -412,6 +418,12 @@ spec:
                   is used if CNAME record for DNS01 challange domain ` + "`" + `_acme-challenge.<domain>` + "`" + `
                   is set.
                 type: boolean
+              ipAddresses:
+                description: IPAddresses are the optional requested IP address subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               isCA:
                 description: |-
                   IsCA value is used to set the ` + "`" + `isCA` + "`" + ` field on the certificate request.
@@ -566,6 +578,12 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              uris:
+                description: URIs are the optional requested URI subject alternative
+                  names.
+                items:
+                  type: string
+                type: array
             type: object
           status:
             description: CertificateStatus is the status of the certificate request.

--- a/pkg/apis/cert/v1alpha1/types.go
+++ b/pkg/apis/cert/v1alpha1/types.go
@@ -53,6 +53,15 @@ type CertificateSpec struct {
 	// DNSNames are the optional additional domain names of the certificate.
 	// +optional
 	DNSNames []string `json:"dnsNames,omitempty"`
+	// EmailAddresses are the optional requested email subject alternative names.
+	// +optional
+	EmailAddresses []string `json:"emailAddresses,omitempty"`
+	// IPAddresses are the optional requested IP address subject alternative names.
+	// +optional
+	IPAddresses []string `json:"ipAddresses,omitempty"`
+	// URIs are the optional requested URI subject alternative names.
+	// +optional
+	URIs []string `json:"uris,omitempty"`
 	// CSR is the alternative way to provide CN,DNSNames and other information.
 	// +optional
 	CSR []byte `json:"csr,omitempty"`

--- a/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
@@ -397,6 +397,21 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EmailAddresses != nil {
+		in, out := &in.EmailAddresses, &out.EmailAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.IPAddresses != nil {
+		in, out := &in.IPAddresses, &out.IPAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.URIs != nil {
+		in, out := &in.URIs, &out.URIs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.CSR != nil {
 		in, out := &in.CSR, &out.CSR
 		*out = make([]byte, len(*in))

--- a/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
+++ b/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
@@ -97,6 +97,12 @@ spec:
                   Must be at least twice the renewal window.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
+              emailAddresses:
+                description: EmailAddresses are the optional requested email subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               ensureRenewedAfter:
                 description: EnsureRenewedAfter specifies a time stamp in the past.
                   Renewing is only triggered if certificate notBefore date is before
@@ -108,6 +114,12 @@ spec:
                   is used if CNAME record for DNS01 challange domain `_acme-challenge.<domain>`
                   is set.
                 type: boolean
+              ipAddresses:
+                description: IPAddresses are the optional requested IP address subject
+                  alternative names.
+                items:
+                  type: string
+                type: array
               isCA:
                 description: |-
                   IsCA value is used to set the `isCA` field on the certificate request.
@@ -262,6 +274,12 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              uris:
+                description: URIs are the optional requested URI subject alternative
+                  names.
+                items:
+                  type: string
+                type: array
             type: object
           status:
             description: CertificateStatus is the status of the certificate request.

--- a/pkg/controller/issuer/certificate/utils.go
+++ b/pkg/controller/issuer/certificate/utils.go
@@ -8,7 +8,11 @@ package certificate
 
 import (
 	"crypto/x509"
+	"fmt"
 	"math/big"
+	"net"
+	"net/mail"
+	"net/url"
 	"strings"
 	"time"
 
@@ -84,6 +88,54 @@ func LookupSerialNumber(res resources.Interface, ref *corev1.SecretReference) (s
 		return "", err
 	}
 	return SerialNumberToString(cert.SerialNumber, false), nil
+}
+
+// ValidateEmailAddresses checks if the provided email addresses are valid.
+func ValidateEmailAddresses(emails []string) error {
+	if len(emails) == 0 {
+		return nil
+	}
+	for _, email := range emails {
+		if _, err := mail.ParseAddress(email); err != nil {
+			return fmt.Errorf("invalid email address: %s, error: %w", email, err)
+		}
+	}
+	return nil
+}
+
+// ParseIPAddresses parses a list of IP addresses and returns a slice of net.IP objects.
+func ParseIPAddresses(ips []string) ([]net.IP, error) {
+	if len(ips) == 0 {
+		return nil, nil
+	}
+	var parsedIPs []net.IP
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			return nil, fmt.Errorf("invalid IP address: %s", ip)
+		}
+		parsedIPs = append(parsedIPs, parsedIP)
+	}
+	return parsedIPs, nil
+}
+
+// ParseURIs parses a list of URIs and returns a slice of parsed *url.URL objects.
+func ParseURIs(uris []string) ([]*url.URL, error) {
+	if len(uris) == 0 {
+		return nil, nil
+	}
+	var parsedURIs []*url.URL
+	for _, uri := range uris {
+		parsedURI, err := url.Parse(uri)
+		if err != nil {
+			return nil, fmt.Errorf("invalid URI: %s, error: %w", uri, err)
+		}
+		if parsedURI.Scheme == "" {
+			return nil, fmt.Errorf("invalid URI: %s, scheme is missing", uri)
+		}
+		parsedURIs = append(parsedURIs, parsedURI)
+	}
+	return parsedURIs, nil
 }
 
 func hasMultipleIssuerTypes(issuer *api.Issuer) bool {

--- a/pkg/controller/issuer/certificate/utils_test.go
+++ b/pkg/controller/issuer/certificate/utils_test.go
@@ -5,6 +5,9 @@
 package certificate
 
 import (
+	"net"
+	"net/url"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -32,6 +35,106 @@ var _ = Describe("Utils", func() {
 			issuer.Spec.ACME = &api.ACMESpec{}
 			issuer.Spec.SelfSigned = &api.SelfSignedSpec{}
 			Expect(hasMultipleIssuerTypes(issuer)).To(BeTrue())
+		})
+	})
+
+	Context("#ValidateEmailAddresses", func() {
+		It("should return no error when passing no email addresses", func() {
+			err := ValidateEmailAddresses(nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return no error when passing a single, valid email address", func() {
+			err := ValidateEmailAddresses([]string{"foo@example.com"})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return no error when passing multiple valid email addresses", func() {
+			err := ValidateEmailAddresses([]string{"foo@example.com", "bar@example.com"})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return an error when passing a single, invalid email address", func() {
+			err := ValidateEmailAddresses([]string{"invalid-email"})
+			Expect(err).To(MatchError("invalid email address: invalid-email, error: mail: missing '@' or angle-addr"))
+		})
+
+		It("should return an error when passing multiple, invalid email addresses", func() {
+			err := ValidateEmailAddresses([]string{"not-this", "not-that"})
+			Expect(err).To(MatchError("invalid email address: not-this, error: mail: missing '@' or angle-addr"))
+		})
+	})
+
+	Context("#ParseIPAddresses", func() {
+		It("should return no error when passing no IP addresses", func() {
+			ips, err := ParseIPAddresses(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ips).To(BeNil())
+		})
+
+		It("should return a single IP address when passing a valid one", func() {
+			ips, err := ParseIPAddresses([]string{"1.1.1.1"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ips).To(Equal([]net.IP{net.ParseIP("1.1.1.1")}))
+		})
+
+		It("should return multiple IP addresses when passing valid ones", func() {
+			ips, err := ParseIPAddresses([]string{"1.1.1.1", "1.0.0.1"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ips).To(Equal([]net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("1.0.0.1")}))
+		})
+
+		It("should return an error when passing an invalid IP address", func() {
+			ips, err := ParseIPAddresses([]string{"invalid-ip"})
+			Expect(err).To(MatchError("invalid IP address: invalid-ip"))
+			Expect(ips).To(BeNil())
+		})
+
+		It("should return an error when passing multiple invalid IP addresses", func() {
+			ips, err := ParseIPAddresses([]string{"not-this", "not-that"})
+			Expect(err).To(MatchError("invalid IP address: not-this"))
+			Expect(ips).To(BeNil())
+		})
+	})
+
+	Context("#ParseURIs", func() {
+		It("should return no error when passing no URIs", func() {
+			uris, err := ParseURIs(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uris).To(BeNil())
+		})
+
+		It("should return a single URI when passing a valid one", func() {
+			uris, err := ParseURIs([]string{"https://example.com"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uris).To(Equal([]*url.URL{{Scheme: "https", Host: "example.com"}}))
+		})
+
+		It("should return multiple URIs when passing valid ones", func() {
+			uris, err := ParseURIs([]string{"https://example.com", "http://example.org"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uris).To(Equal([]*url.URL{
+				{Scheme: "https", Host: "example.com"},
+				{Scheme: "http", Host: "example.org"},
+			}))
+		})
+
+		It("should return an error when passing an invalid URI", func() {
+			uris, err := ParseURIs([]string{":foo/bar"})
+			Expect(err).To(MatchError("invalid URI: :foo/bar, error: parse \":foo/bar\": missing protocol scheme"))
+			Expect(uris).To(BeNil())
+		})
+
+		It("should return an error when passing an URI without a scheme", func() {
+			uris, err := ParseURIs([]string{"foo/bar"})
+			Expect(err).To(MatchError("invalid URI: foo/bar, scheme is missing"))
+			Expect(uris).To(BeNil())
+		})
+
+		It("should return an error when passing multiple invalid URIs", func() {
+			uris, err := ParseURIs([]string{":not-this", ":not-that"})
+			Expect(err).To(MatchError("invalid URI: :not-this, error: parse \":not-this\": missing protocol scheme"))
+			Expect(uris).To(BeNil())
 		})
 	})
 })

--- a/pkg/shared/legobridge/certificate.go
+++ b/pkg/shared/legobridge/certificate.go
@@ -10,6 +10,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -47,6 +49,12 @@ type ObtainInput struct {
 	CommonName *string
 	// DNSNames are optional domain names.
 	DNSNames []string
+	// EmailAddresses are optional email subject alternative names.
+	EmailAddresses []string
+	// IPAddresses are optional IP address subject alternative names.
+	IPAddresses []net.IP
+	// URIs are optional URI subject alternative names.
+	URIs []*url.URL
 	// CSR is the optional Certificate Signing Request.
 	CSR []byte
 	// Request name is the request object name.

--- a/pkg/shared/legobridge/pki.go
+++ b/pkg/shared/legobridge/pki.go
@@ -151,6 +151,10 @@ func createCertReq(input ObtainInput) (*x509.CertificateRequest, error) {
 		return nil, fmt.Errorf("failed to generate private key for type %v: %w", input.KeyType, err)
 	}
 
+	var emailAddresses []string
+	emailAddresses = append(emailAddresses, input.CAKeyPair.Cert.EmailAddresses...)
+	emailAddresses = append(emailAddresses, input.EmailAddresses...)
+
 	return &x509.CertificateRequest{
 		Version:            3,
 		PublicKeyAlgorithm: getPublicKeyAlgorithm(privateKey),
@@ -166,7 +170,9 @@ func createCertReq(input ObtainInput) (*x509.CertificateRequest, error) {
 			PostalCode:         subjectCA.PostalCode,
 		},
 		DNSNames:       input.DNSNames,
-		EmailAddresses: input.CAKeyPair.Cert.EmailAddresses,
+		EmailAddresses: emailAddresses,
+		IPAddresses:    input.IPAddresses,
+		URIs:           input.URIs,
 	}, nil
 }
 
@@ -254,6 +260,8 @@ func generateCertFromCSR(csrPEM []byte, duration time.Duration, isCA bool) (*x50
 		ExtKeyUsage:           DefaultCertExtKeyUsage,
 		DNSNames:              csr.DNSNames,
 		EmailAddresses:        csr.EmailAddresses,
+		IPAddresses:           csr.IPAddresses,
+		URIs:                  csr.URIs,
 	}, nil
 }
 
@@ -281,6 +289,9 @@ func newSelfSignedCertInPEMFormat(
 			CommonName: *input.CommonName,
 		},
 		DNSNames:              input.DNSNames,
+		EmailAddresses:        input.EmailAddresses,
+		IPAddresses:           input.IPAddresses,
+		URIs:                  input.URIs,
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(*input.Duration),
 		KeyUsage:              keyUsage,

--- a/test/integration/controller/issuer/certificate_test.go
+++ b/test/integration/controller/issuer/certificate_test.go
@@ -6,8 +6,13 @@ package issuer_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
+	"net"
+	"net/url"
 	"time"
 
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -123,6 +128,133 @@ var _ = Describe("Certificate controller tests", func() {
 			expired, _ := time.Parse(time.RFC3339, *expirationDate)
 			Expect(issued).To(BeTemporally("<", expired))
 		})
+
+		It("should be properly created with subject alternative names (SANs)", func() {
+			By("Create self-signed certificate with SANs")
+			certificate := &certv1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testNamespace.Name,
+					GenerateName: "self-signed-certificate-with-sans-",
+				},
+				Spec: certv1alpha1.CertificateSpec{
+					IssuerRef: &certv1alpha1.IssuerRef{
+						Namespace: selfSignedIssuer.Namespace,
+						Name:      selfSignedIssuer.Name,
+					},
+					IsCA:           ptr.To(true),
+					CommonName:     ptr.To("example.com"),
+					EmailAddresses: []string{"foo@example.com", "bar@example.com"},
+					IPAddresses:    []string{"1.1.1.1", "1.0.0.1"},
+					URIs:           []string{"ftp://ftp.example.com", "urn:isbn:9780718097914"},
+				},
+			}
+			Expect(testClient.Create(ctx, certificate)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, certificate)).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(certificate), certificate)).To(Succeed())
+				g.Expect(certificate.Status.State).To(Equal("Ready"))
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("Read certificate secret")
+			secret := &corev1.Secret{}
+			err := testClient.Get(ctx, client.ObjectKey{
+				Namespace: certificate.Spec.SecretRef.Namespace,
+				Name:      certificate.Spec.SecretRef.Name,
+			}, secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Decode certificate from secret")
+			certBlock, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
+			Expect(certBlock).NotTo(BeNil())
+			parsedCert, err := x509.ParseCertificate(certBlock.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check SANs in the certificate")
+			Expect(parsedCert.EmailAddresses).To(ConsistOf("foo@example.com", "bar@example.com"))
+			Expect(parsedCert.IPAddresses).To(ConsistOf(net.ParseIP("1.1.1.1").To4(), net.ParseIP("1.0.0.1").To4()))
+			Expect(parsedCert.URIs).To(ConsistOf(&url.URL{Scheme: "ftp", Host: "ftp.example.com"}, &url.URL{Scheme: "urn", Opaque: "isbn:9780718097914"}))
+		})
+
+		It("should be properly created with SANs through a certificate signing request (CSR)", func() {
+			By("Create a CSR")
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).NotTo(HaveOccurred())
+			certificateRequest := x509.CertificateRequest{
+				Subject: pkix.Name{
+					CommonName: "example.com",
+				},
+				EmailAddresses: []string{"foo@example.com", "bar@example.com"},
+				IPAddresses:    []net.IP{net.ParseIP("1.1.1.1").To4(), net.ParseIP("1.0.0.1").To4()},
+				URIs:           []*url.URL{{Scheme: "ftp", Host: "ftp.example.com"}, {Scheme: "urn", Opaque: "isbn:9780718097914"}},
+			}
+			csrDER, err := x509.CreateCertificateRequest(rand.Reader, &certificateRequest, privateKey)
+			Expect(err).NotTo(HaveOccurred())
+			csrPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE REQUEST",
+				Bytes: csrDER,
+			})
+
+			By("Create self-signed certificate with SANs through CSR")
+			certificate := &certv1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testNamespace.Name,
+					GenerateName: "self-signed-certificate-with-sans-csr-",
+				},
+				Spec: certv1alpha1.CertificateSpec{
+					IssuerRef: &certv1alpha1.IssuerRef{
+						Namespace: selfSignedIssuer.Namespace,
+						Name:      selfSignedIssuer.Name,
+					},
+					IsCA: ptr.To(true),
+					CSR:  csrPEM,
+				},
+			}
+			Expect(testClient.Create(ctx, certificate)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, certificate)).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(certificate), certificate)).To(Succeed())
+				g.Expect(certificate.Status.State).To(Equal("Ready"))
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+		})
+
+		DescribeTable("should reject invalid SAN values",
+			func(emailAddresses []string, ipAddresses []string, uris []string, expectedErrorMessage string) {
+				By("Create self-signed certificate with SANs")
+				certificate := &certv1alpha1.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:    testNamespace.Name,
+						GenerateName: "self-signed-certificate-with-sans-",
+					},
+					Spec: certv1alpha1.CertificateSpec{
+						IssuerRef: &certv1alpha1.IssuerRef{
+							Namespace: selfSignedIssuer.Namespace,
+							Name:      selfSignedIssuer.Name,
+						},
+						IsCA:           ptr.To(true),
+						CommonName:     ptr.To("example.com"),
+						EmailAddresses: emailAddresses,
+						IPAddresses:    ipAddresses,
+						URIs:           uris,
+					},
+				}
+				Expect(testClient.Create(ctx, certificate)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testClient.Delete(ctx, certificate)).To(Succeed())
+				})
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(certificate), certificate)).To(Succeed())
+					g.Expect(certificate.Status.State).To(Equal("Error"))
+					g.Expect(*certificate.Status.Message).To(ContainSubstring(expectedErrorMessage))
+				}).WithTimeout(5 * time.Second).Should(Succeed())
+			},
+			Entry("invalid email", []string{"invalid-email"}, nil, nil, "invalid email address"),
+			Entry("invalid ip", nil, []string{"invalid-ip"}, nil, "invalid IP address"),
+			Entry("invalid uri", nil, nil, []string{":foo/bar"}, "invalid URI"),
+		)
 	})
 
 	Context("Self-signed certificates from CA issuer", func() {
@@ -256,5 +388,101 @@ var _ = Describe("Certificate controller tests", func() {
 			Entry("RSA 3072", certv1alpha1.RSAKeyAlgorithm, 3072),
 			Entry("RSA 4096", certv1alpha1.RSAKeyAlgorithm, 4096),
 		)
+
+		It("should be properly created with subject alternative names (SANs)", func() {
+			By("Create certificate from CA with SANs")
+			certificate := &certv1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testNamespace.Name,
+					GenerateName: "ca-certificate-with-sans-",
+				},
+				Spec: certv1alpha1.CertificateSpec{
+					IssuerRef: &certv1alpha1.IssuerRef{
+						Namespace: caIssuer.Namespace,
+						Name:      caIssuer.Name,
+					},
+					CommonName: ptr.To("example.com"),
+					Duration: &metav1.Duration{
+						Duration: 48 * time.Hour,
+					},
+					EmailAddresses: []string{"foo@example.com", "bar@example.com"},
+					IPAddresses:    []string{"1.1.1.1", "1.0.0.1"},
+					URIs:           []string{"ftp://ftp.example.com", "urn:isbn:9780718097914"},
+				},
+			}
+			Expect(testClient.Create(ctx, certificate)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, certificate)).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(certificate), certificate)).To(Succeed())
+				g.Expect(certificate.Status.State).To(Equal("Ready"))
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+
+			By("Read certificate secret")
+			secret := &corev1.Secret{}
+			err := testClient.Get(ctx, client.ObjectKey{
+				Namespace: certificate.Spec.SecretRef.Namespace,
+				Name:      certificate.Spec.SecretRef.Name,
+			}, secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Decode certificate from secret")
+			certBlock, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
+			Expect(certBlock).NotTo(BeNil())
+			parsedCert, err := x509.ParseCertificate(certBlock.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check SANs in the certificate")
+			Expect(parsedCert.EmailAddresses).To(ConsistOf("foo@example.com", "bar@example.com"))
+			Expect(parsedCert.IPAddresses).To(ConsistOf(net.ParseIP("1.1.1.1").To4(), net.ParseIP("1.0.0.1").To4()))
+			Expect(parsedCert.URIs).To(ConsistOf(&url.URL{Scheme: "ftp", Host: "ftp.example.com"}, &url.URL{Scheme: "urn", Opaque: "isbn:9780718097914"}))
+		})
+
+		It("should be properly created with SANs through a certificate signing request (CSR)", func() {
+			By("Create a CSR")
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).NotTo(HaveOccurred())
+			certificateRequest := x509.CertificateRequest{
+				Subject: pkix.Name{
+					CommonName: "example.com",
+				},
+				EmailAddresses: []string{"foo@example.com", "bar@example.com"},
+				IPAddresses:    []net.IP{net.ParseIP("1.1.1.1").To4(), net.ParseIP("1.0.0.1").To4()},
+				URIs:           []*url.URL{{Scheme: "ftp", Host: "ftp.example.com"}, {Scheme: "urn", Opaque: "isbn:9780718097914"}},
+			}
+			csrDER, err := x509.CreateCertificateRequest(rand.Reader, &certificateRequest, privateKey)
+			Expect(err).NotTo(HaveOccurred())
+			csrPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE REQUEST",
+				Bytes: csrDER,
+			})
+
+			By("Create certificate from CA with SANs through CSR")
+			certificate := &certv1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testNamespace.Name,
+					GenerateName: "ca-certificate-with-sans-csr-",
+				},
+				Spec: certv1alpha1.CertificateSpec{
+					IssuerRef: &certv1alpha1.IssuerRef{
+						Namespace: caIssuer.Namespace,
+						Name:      caIssuer.Name,
+					},
+					Duration: &metav1.Duration{
+						Duration: 48 * time.Hour,
+					},
+					CSR: csrPEM,
+				},
+			}
+			Expect(testClient.Create(ctx, certificate)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, certificate)).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(certificate), certificate)).To(Succeed())
+				g.Expect(certificate.Status.State).To(Equal("Ready"))
+			}).WithTimeout(10 * time.Second).Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind api-change
/kind task

**What this PR does / why we need it**:

This PR extends support for subject alternative names (SANs) in the `Certificate` spec.
The following fields are added:
- `.spec.emailAddresses`
- `.spec.ipAddresses`
- `.spec.uris`

Additionally, SANs can be specified in certificate signing requests (CSRs).

**Which issue(s) this PR fixes**:
Fixes #449 

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added support for subject alternative names (SANs) in the `Certificate` spec and certificate signing requests (CSRs). The following SANs have been added: `emailAddresses`, `ipAddresses`, and `uris`.
```
