### PR TITLE
feat: Extend Certificate controller implementation using controller-runtime

### DIFF
--- a/pkg/certman2/controller/certificate/add.go
+++ b/pkg/certman2/controller/certificate/add.go
@@ -34,6 +34,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 			&v1alpha1.Certificate{},
 			builder.WithPredicates(
 				certcontroller.CertClassPredicate(r.Config.Class),
+				PendingCertificateRequestPredicate(r.pendingRequests),
 			),
 		).
 		WithOptions(controller.Options{

--- a/pkg/certman2/controller/certificate/predicate.go
+++ b/pkg/certman2/controller/certificate/predicate.go
@@ -15,9 +15,6 @@ import (
 // PendingCertificateRequestPredicate returns a predicate that filters objects if they have a pending certificate request.
 func PendingCertificateRequestPredicate(pendingRequests *legobridge.PendingCertificateRequests) predicate.Predicate {
 	return controller.FilterPredicate(func(obj client.Object) bool {
-		return !pendingRequests.Contains(client.ObjectKey{
-			Namespace: obj.GetNamespace(),
-			Name:      obj.GetName(),
-		})
+		return !pendingRequests.Contains(client.ObjectKeyFromObject(obj))
 	})
 }

--- a/pkg/certman2/controller/certificate/predicate.go
+++ b/pkg/certman2/controller/certificate/predicate.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package certificate
+
+import (
+	"github.com/gardener/cert-management/pkg/certman2/controller"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// PendingCertificateRequestPredicate returns a predicate that filters objects if they have a pending certificate request.
+func PendingCertificateRequestPredicate(pendingRequests *legobridge.PendingCertificateRequests) predicate.Predicate {
+	return controller.FilterPredicate(func(obj client.Object) bool {
+		return !pendingRequests.Contains(client.ObjectKey{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+		})
+	})
+}

--- a/pkg/certman2/controller/certificate/predicate.go
+++ b/pkg/certman2/controller/certificate/predicate.go
@@ -5,10 +5,11 @@
 package certificate
 
 import (
-	"github.com/gardener/cert-management/pkg/certman2/controller"
-	"github.com/gardener/cert-management/pkg/shared/legobridge"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/cert-management/pkg/certman2/controller"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
 )
 
 // PendingCertificateRequestPredicate returns a predicate that filters objects if they have a pending certificate request.

--- a/pkg/certman2/controller/certificate/predicate_test.go
+++ b/pkg/certman2/controller/certificate/predicate_test.go
@@ -5,14 +5,15 @@
 package certificate
 
 import (
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/cert-management/pkg/shared/legobridge"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
 )
 
 var _ = Describe("Certificate controller predicates", func() {

--- a/pkg/certman2/controller/certificate/predicate_test.go
+++ b/pkg/certman2/controller/certificate/predicate_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package certificate
+
+import (
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ = Describe("Certificate controller predicates", func() {
+	Context("#PendingCertificateRequestPredicate", func() {
+		var (
+			evt             event.TypedCreateEvent[client.Object]
+			pendingRequests *legobridge.PendingCertificateRequests
+			predicateFunc   predicate.Predicate
+		)
+
+		BeforeEach(func() {
+			evt = event.TypedCreateEvent[client.Object]{
+				Object: &v1alpha1.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "cert0",
+					},
+				},
+			}
+			pendingRequests = legobridge.NewPendingRequests()
+			predicateFunc = PendingCertificateRequestPredicate(pendingRequests)
+		})
+
+		It("should filter out objects with pending requests", func() {
+			pendingRequests.Add(client.ObjectKey{Namespace: "default", Name: "cert0"})
+			Expect(predicateFunc.Create(evt)).To(BeFalse())
+		})
+
+		It("should allow objects without pending requests", func() {
+			Expect(predicateFunc.Create(evt)).To(BeTrue())
+		})
+
+		It("should allow objects after pending requests are cleared", func() {
+			pendingRequests.Add(client.ObjectKey{Namespace: "default", Name: "cert0"})
+			Expect(predicateFunc.Create(evt)).To(BeFalse())
+			pendingRequests.Remove(client.ObjectKey{Namespace: "default", Name: "cert0"})
+			Expect(predicateFunc.Create(evt)).To(BeTrue())
+		})
+	})
+})

--- a/pkg/certman2/controller/certificate/reconciler.go
+++ b/pkg/certman2/controller/certificate/reconciler.go
@@ -7,12 +7,12 @@ package certificate
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/pkg/certman2/controller/certificate/reconciler.go
+++ b/pkg/certman2/controller/certificate/reconciler.go
@@ -7,6 +7,7 @@ package certificate
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
@@ -25,6 +26,9 @@ type Reconciler struct {
 	Clock    clock.Clock
 	Recorder record.EventRecorder
 	Config   config.CertManagerConfiguration
+
+	pendingRequests *legobridge.PendingCertificateRequests
+	pendingResults  *legobridge.PendingResults
 }
 
 // Reconcile reconciles Certificate resources.

--- a/pkg/certman2/controller/certificate/reconciler.go
+++ b/pkg/certman2/controller/certificate/reconciler.go
@@ -33,7 +33,10 @@ type Reconciler struct {
 
 // Reconcile reconciles Certificate resources.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := logf.FromContext(ctx).WithName(ControllerName)
+	log := logf.FromContext(ctx).WithName(ControllerName).WithValues(
+		"namespace", req.Namespace,
+		"name", req.Name,
+	)
 
 	cert := &v1alpha1.Certificate{}
 	if err := r.Client.Get(ctx, req.NamespacedName, cert); err != nil {

--- a/pkg/certman2/controller/certificate/reconciler.go
+++ b/pkg/certman2/controller/certificate/reconciler.go
@@ -7,6 +7,7 @@ package certificate
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,7 +52,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	var (
 		result     reconcile.Result
 		err        error
-		oldMessage = *cert.Status.Message
+		oldMessage = ptr.Deref(cert.Status.Message, "")
 	)
 	if cert.DeletionTimestamp != nil {
 		result, err = r.delete(ctx, log, cert)
@@ -65,7 +66,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 func (r *Reconciler) handleChangedMessage(cert *v1alpha1.Certificate, oldMessage string, err error) {
-	newMessage := *cert.Status.Message
+	newMessage := ptr.Deref(cert.Status.Message, "")
 	if newMessage == oldMessage {
 		return
 	}

--- a/pkg/certman2/controller/certificate/reconciler.go
+++ b/pkg/certman2/controller/certificate/reconciler.go
@@ -7,9 +7,8 @@ package certificate
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/cert-management/pkg/shared/legobridge"
-	corev1 "k8s.io/api/core/v1"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/certman2/apis/config"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
 )
 
 // Reconciler is a reconciler for provided Certificate resources.

--- a/pkg/certman2/controller/certificate/reconciler_reconcile.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile.go
@@ -17,13 +17,40 @@ import (
 func (r *Reconciler) reconcile(
 	ctx context.Context,
 	log logr.Logger,
-	landscape *v1alpha1.Certificate,
+	cert *v1alpha1.Certificate,
 ) (
 	reconcile.Result,
 	error,
 ) {
-	log.Info("reconcile certificate")
-	_ = ctx
-	_ = landscape
+	log.Info("reconcile cert")
+
+	if r.isOrphanedPendingCertificate(cert) {
+		return r.handleOrphanedPendingCertificate(ctx, cert)
+	}
+
 	return reconcile.Result{}, fmt.Errorf("not yet supported")
+}
+
+func (r *Reconciler) isOrphanedPendingCertificate(cert *v1alpha1.Certificate) bool {
+	return cert.Status.State == v1alpha1.StatePending && !r.hasPendingChallenge(cert) && !r.hasResultPending(cert)
+}
+
+// handleOrphanedPendingCertificate cleans up invalid orphaned pending state unfinished from former controller instance, resets status to trigger a retry.
+func (r *Reconciler) handleOrphanedPendingCertificate(ctx context.Context, cert *v1alpha1.Certificate) (reconcile.Result, error) {
+	cert.Status.LastPendingTimestamp = nil
+	err := r.Client.Update(ctx, cert)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to update certificate status: %w", err)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) hasPendingChallenge(_ *v1alpha1.Certificate) bool {
+	// TODO
+	return false
+}
+
+func (r *Reconciler) hasResultPending(_ *v1alpha1.Certificate) bool {
+	// TODO
+	return false
 }

--- a/pkg/certman2/controller/certificate/reconciler_reconcile.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile.go
@@ -7,11 +7,11 @@ package certificate
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"

--- a/pkg/certman2/controller/certificate/reconciler_reconcile.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile.go
@@ -25,7 +25,7 @@ func (r *Reconciler) reconcile(
 	reconcile.Result,
 	error,
 ) {
-	log.Info("reconcile cert")
+	log.Info("reconcile certificate")
 
 	if r.isOrphanedPendingCertificate(cert) {
 		log.Info("orphaned pending certificate detected")

--- a/pkg/certman2/controller/certificate/reconciler_reconcile.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile.go
@@ -39,6 +39,7 @@ func (r *Reconciler) isOrphanedPendingCertificate(cert *v1alpha1.Certificate) bo
 // handleOrphanedPendingCertificate cleans up invalid orphaned pending state unfinished from former controller instance, resets status to trigger a retry.
 func (r *Reconciler) handleOrphanedPendingCertificate(ctx context.Context, cert *v1alpha1.Certificate) (reconcile.Result, error) {
 	cert.Status.LastPendingTimestamp = nil
+	cert.Status.State = ""
 	err := r.Client.Update(ctx, cert)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to update certificate status: %w", err)

--- a/pkg/certman2/controller/certificate/reconciler_reconcile.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile.go
@@ -7,6 +7,7 @@ package certificate
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -45,12 +46,10 @@ func (r *Reconciler) handleOrphanedPendingCertificate(ctx context.Context, cert 
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) hasPendingChallenge(_ *v1alpha1.Certificate) bool {
-	// TODO
-	return false
+func (r *Reconciler) hasPendingChallenge(cert *v1alpha1.Certificate) bool {
+	return r.pendingRequests.Contains(client.ObjectKeyFromObject(cert))
 }
 
-func (r *Reconciler) hasResultPending(_ *v1alpha1.Certificate) bool {
-	// TODO
-	return false
+func (r *Reconciler) hasResultPending(cert *v1alpha1.Certificate) bool {
+	return r.pendingResults.Peek(client.ObjectKeyFromObject(cert)) != nil
 }

--- a/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
@@ -5,12 +5,18 @@
 package certificate
 
 import (
+	"context"
 	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
 	"github.com/gardener/cert-management/pkg/shared/legobridge"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"time"
 )
 
 var _ = Describe("Certificate reconcile", func() {
@@ -27,8 +33,8 @@ var _ = Describe("Certificate reconcile", func() {
 			}
 			cert = &v1alpha1.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    "default",
-					GenerateName: "cert-",
+					Namespace: "default",
+					Name:      "cert",
 				},
 			}
 		})
@@ -53,6 +59,33 @@ var _ = Describe("Certificate reconcile", func() {
 			cert.Status.State = v1alpha1.StatePending
 			reconciler.pendingResults.Add(client.ObjectKeyFromObject(cert), &legobridge.ObtainOutput{})
 			Expect(reconciler.isOrphanedPendingCertificate(cert)).To(BeFalse())
+		})
+	})
+
+	Context("#handleOrphanedPendingCertificate", func() {
+		It("should clear the last pending timestamp and reset the certificate status", func() {
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(certmanclient.ClusterScheme).Build()
+			reconciler := &Reconciler{
+				Client: fakeClient,
+			}
+
+			cert := &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    "default",
+					GenerateName: "cert-",
+				},
+				Status: v1alpha1.CertificateStatus{
+					State:                v1alpha1.StatePending,
+					LastPendingTimestamp: ptr.To(metav1.NewTime(time.Now())),
+				},
+			}
+			Expect(fakeClient.Create(context.TODO(), cert)).To(Succeed())
+
+			result, err := reconciler.handleOrphanedPendingCertificate(context.TODO(), cert)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(cert.Status.LastPendingTimestamp).To(BeNil())
+			Expect(cert.Status.State).To(Equal(""))
 		})
 	})
 })

--- a/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package certificate
+
+import (
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Certificate reconcile", func() {
+	Context("#isOrphanedPendingCertificate", func() {
+		var (
+			reconciler *Reconciler
+			cert       *v1alpha1.Certificate
+		)
+
+		BeforeEach(func() {
+			reconciler = &Reconciler{
+				pendingRequests: legobridge.NewPendingRequests(),
+				pendingResults:  legobridge.NewPendingResults(),
+			}
+			cert = &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    "default",
+					GenerateName: "cert-",
+				},
+			}
+		})
+
+		It("should return true for an orphaned pending certificate", func() {
+			cert.Status.State = v1alpha1.StatePending
+			Expect(reconciler.isOrphanedPendingCertificate(cert)).To(BeTrue())
+		})
+
+		It("should return false for a non-pending certificate", func() {
+			cert.Status.State = v1alpha1.StateReady
+			Expect(reconciler.isOrphanedPendingCertificate(cert)).To(BeFalse())
+		})
+
+		It("should return false when the certificate has a pending challenge", func() {
+			cert.Status.State = v1alpha1.StatePending
+			reconciler.pendingRequests.Add(client.ObjectKeyFromObject(cert))
+			Expect(reconciler.isOrphanedPendingCertificate(cert)).To(BeFalse())
+		})
+
+		It("should return false when the certificate has a pending result", func() {
+			cert.Status.State = v1alpha1.StatePending
+			reconciler.pendingResults.Add(client.ObjectKeyFromObject(cert), &legobridge.ObtainOutput{})
+			Expect(reconciler.isOrphanedPendingCertificate(cert)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
@@ -88,4 +88,66 @@ var _ = Describe("Certificate reconcile", func() {
 			Expect(cert.Status.State).To(Equal(""))
 		})
 	})
+
+	Context("#hasPendingChallenge", func() {
+		var reconciler *Reconciler
+
+		BeforeEach(func() {
+			reconciler = &Reconciler{
+				pendingRequests: legobridge.NewPendingRequests(),
+			}
+		})
+
+		It("should return true if the certificate has a pending requests", func() {
+			cert := &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cert",
+				},
+			}
+			reconciler.pendingRequests.Add(client.ObjectKeyFromObject(cert))
+			Expect(reconciler.hasPendingChallenge(cert)).To(BeTrue())
+		})
+
+		It("should return false if the certificate does not have a pending requests", func() {
+			cert := &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cert",
+				},
+			}
+			Expect(reconciler.hasPendingChallenge(cert)).To(BeFalse())
+		})
+	})
+
+	Context("#hasResultPending", func() {
+		var reconciler *Reconciler
+
+		BeforeEach(func() {
+			reconciler = &Reconciler{
+				pendingResults: legobridge.NewPendingResults(),
+			}
+		})
+
+		It("should return true if the certificate has a pending result", func() {
+			cert := &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cert",
+				},
+			}
+			reconciler.pendingResults.Add(client.ObjectKeyFromObject(cert), &legobridge.ObtainOutput{})
+			Expect(reconciler.hasResultPending(cert)).To(BeTrue())
+		})
+
+		It("should return false if the certificate does not have a pending results", func() {
+			cert := &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cert",
+				},
+			}
+			Expect(reconciler.hasResultPending(cert)).To(BeFalse())
+		})
+	})
 })

--- a/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_reconcile_test.go
@@ -6,9 +6,8 @@ package certificate
 
 import (
 	"context"
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
-	"github.com/gardener/cert-management/pkg/shared/legobridge"
+	"time"
+
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,7 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
+
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
 )
 
 var _ = Describe("Certificate reconcile", func() {

--- a/pkg/certman2/controller/certificate/reconciler_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_test.go
@@ -6,9 +6,8 @@ package certificate
 
 import (
 	"context"
-	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
-	"github.com/gardener/cert-management/pkg/shared/legobridge"
+	"time"
+
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,7 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
+
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
 )
 
 var _ = Describe("#Reconcile", func() {

--- a/pkg/certman2/controller/certificate/reconciler_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package certificate
+
+import (
+	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
+	. "github.com/onsi/ginkgo/v2"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("#Reconcile", func() {
+	var (
+		ctx        context.Context
+		reconciler *Reconciler
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		reconciler = &Reconciler{
+			Client: fakeclient.NewClientBuilder().WithScheme(certmanclient.ClusterScheme).Build(),
+		}
+	})
+
+	It("should return an error if it can't retrieve the certificate", func() {
+		Expect(reconciler.Reconcile())
+	})
+})

--- a/pkg/certman2/controller/certificate/reconciler_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_test.go
@@ -5,24 +5,95 @@
 package certificate
 
 import (
+	"context"
+	"github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
+	"github.com/gardener/cert-management/pkg/shared/legobridge"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"time"
 )
 
 var _ = Describe("#Reconcile", func() {
 	var (
 		reconciler *Reconciler
+		fakeClient client.Client
+		ctx        context.Context
+		cert       *v1alpha1.Certificate
+		request    reconcile.Request
 	)
 
 	BeforeEach(func() {
+		ctx = context.TODO()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(certmanclient.ClusterScheme).Build()
 		reconciler = &Reconciler{
-			Client: fakeclient.NewClientBuilder().WithScheme(certmanclient.ClusterScheme).Build(),
+			Client:          fakeClient,
+			pendingRequests: legobridge.NewPendingRequests(),
+			pendingResults:  legobridge.NewPendingResults(),
 		}
+		cert = &v1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   "default",
+				Name:        "cert",
+				Annotations: map[string]string{},
+			},
+			Status: v1alpha1.CertificateStatus{
+				Message: ptr.To(""),
+			},
+		}
+		request = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cert)}
+
+		Expect(fakeClient.Create(ctx, cert)).To(Succeed())
 	})
 
-	It("should return an error if it can't retrieve the certificate", func() {
-		Expect(reconciler).NotTo(BeNil())
+	It("should reconcile successfully", func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+	})
+
+	It("should handle an orphaned pending certificate", func() {
+		cert.Status.LastPendingTimestamp = &metav1.Time{Time: time.Now()}
+		cert.Status.State = v1alpha1.StatePending
+		Expect(fakeClient.Update(ctx, cert)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cert), cert)).To(Succeed())
+		Expect(cert.Status.LastPendingTimestamp).To(BeNil())
+		Expect(cert.Status.State).To(BeEmpty())
+	})
+
+	It("should handle the reconcile annotation", func() {
+		cert.Annotations[constants.GardenerOperationReconcile] = "true"
+		Expect(fakeClient.Update(ctx, cert)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cert), cert)).To(Succeed())
+		Expect(cert.Annotations).NotTo(HaveKey(constants.GardenerOperationReconcile))
+	})
+
+	It("should backoff when required", func() {
+		cert.Generation = 1
+		cert.Status.BackOff = &v1alpha1.BackOffState{
+			ObservedGeneration: cert.Generation,
+			RetryAfter:         metav1.NewTime(time.Now().Add(42 * time.Hour)),
+		}
+		Expect(fakeClient.Update(ctx, cert)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 41*time.Hour))
 	})
 })

--- a/pkg/certman2/controller/certificate/reconciler_test.go
+++ b/pkg/certman2/controller/certificate/reconciler_test.go
@@ -6,25 +6,23 @@ package certificate
 
 import (
 	certmanclient "github.com/gardener/cert-management/pkg/certman2/client"
-	"github.com/gardener/cert-management/pkg/shared/legobridge"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("#Reconcile", func() {
 	var (
-		ctx        context.Context
 		reconciler *Reconciler
 	)
 
 	BeforeEach(func() {
-		ctx = context.TODO()
 		reconciler = &Reconciler{
 			Client: fakeclient.NewClientBuilder().WithScheme(certmanclient.ClusterScheme).Build(),
 		}
 	})
 
 	It("should return an error if it can't retrieve the certificate", func() {
-		Expect(reconciler.Reconcile())
+		Expect(reconciler).NotTo(BeNil())
 	})
 })

--- a/renovate.json5
+++ b/renovate.json5
@@ -47,7 +47,6 @@
     "github.com/beorn7/perks",
     "github.com/blang/semver/v4",
     "github.com/brunoga/deep",
-    "github.com/cenkalti/backoff/v4",
     "github.com/cespare/xxhash/v2",
     "github.com/cyphar/filepath-securejoin",
     "github.com/davecgh/go-spew",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:

This PR is part of the larger [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) rewrite of this project.
The new implementation using `controller-runtime` is kept in a separate folder and executable binary.

This PR adds the following changes to the `Certificate` controller:
* Handling of orphaned, pending `Certificate`s.
* Backoff handling on `Certificate`s.
* Logging of changed status messages as `Event`s on the `Certificate`.
* Filter pending `Certificate`s using a predicate.
* Adding support for the operator reconcile annotation.

**Which issue(s) this PR fixes**:

Part of #453

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
