### PR TITLE
Export testresults as inlined ocm-resource

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,27 +73,40 @@ jobs:
       - name: run-verify
         run: |
           set -eu
-          .ci/verify
-          # verify calls `make sast-report`, which generates `gosec-report.sarif`
           mkdir /tmp/blobs.d
+
+          .ci/verify |& tee /tmp/blobs.d/verify-log.txt
+
+          # verify calls `make sast-report`, which generates `gosec-report.sarif`
+
           tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
-      - name: add-sast-report-to-component-descriptor
+          tar czf /tmp/blobs.d/verify-log.tar.gz -C/tmp/blobs.d verify-log.txt
+      - name: add-reports-to-component-descriptor
         uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
-            name: gosec-report
-            relation: local
-            access:
-              type: localBlob
-              localReference: gosec-report.tar.gz
-            labels:
-              - name: gardener.cloud/purposes
-                value:
-                  - lint
-                  - sast
-                  - gosec
-              - name: gardener.cloud/comment
-                value: |
-                  we use gosec (linter) for SAST scans
-                  see: https://github.com/securego/gosec
+            - name: gosec-report
+              relation: local
+              access:
+                type: localBlob
+                localReference: gosec-report.tar.gz
+              labels:
+                - name: gardener.cloud/purposes
+                  value:
+                    - lint
+                    - sast
+                    - gosec
+                - name: gardener.cloud/comment
+                  value: |
+                    we use gosec (linter) for SAST scans
+                    see: https://github.com/securego/gosec
+            - name: test-results
+              relation: local
+              access:
+                type: localBlob
+                localReference: verify-log.tar.gz
+              labels:
+                - name: gardener.cloud/purposes
+                  value:
+                    - test


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:

Export testresults as inlined ocm-resource

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:
clone of #536 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
