### PR TITLE
feat: Implement `renewBefore` for certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,7 +1156,7 @@ If the field `.spec.ensureRenewedAfter` is set and you want to trigger the renew
 
 You can control the renewal window of a `Certificate` by using `.spec.RenewBefore`.
 The value is a duration string parseable by Go's [`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration).
-It must be at least 5 minutes and less than the configured renewal window. 
+It must be at least 5 minutes and not greater than the issued certificate's duration minus 5 minutes. 
 The controller subtracts the given duration from the _issued_ certificate's expiration date to determine the renewal date.
 You can inspect the planned renewal date in the status field `.status.renewalDate` (also set when no `renewBefore` is given).
 

--- a/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
@@ -262,7 +262,7 @@ spec:
                   RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
                   Note that the actual expiration of the issued certificate is used for the calculation.
                   If not set, the default renewal window is used.
-                  Must be at least 5 minutes and less than the renewal window.
+                  Must be at least 5 minutes and not greater than issued certificate's duration minus 5 minutes.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               secretLabels:

--- a/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
+++ b/charts/cert-management/templates/cert.gardener.cloud_certificates.yaml
@@ -257,6 +257,14 @@ spec:
               renew:
                 description: Renew triggers a renewal if set to true
                 type: boolean
+              renewBefore:
+                description: |-
+                  RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
+                  Note that the actual expiration of the issued certificate is used for the calculation.
+                  If not set, the default renewal window is used.
+                  Must be at least 5 minutes and less than the renewal window.
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                type: string
               secretLabels:
                 additionalProperties:
                   type: string
@@ -415,6 +423,10 @@ spec:
                   spec.
                 format: int64
                 type: integer
+              renewalDate:
+                description: RenewalDate shows the planned renewal date. If not set,
+                  no renewal has been planned yet.
+                type: string
               state:
                 description: State is the certificate state.
                 type: string

--- a/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
+++ b/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
@@ -256,7 +256,7 @@ spec:
                   RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
                   Note that the actual expiration of the issued certificate is used for the calculation.
                   If not set, the default renewal window is used.
-                  Must be at least 5 minutes and less than the renewal window.
+                  Must be at least 5 minutes and not greater than issued certificate's duration minus 5 minutes.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               secretLabels:

--- a/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
+++ b/pkg/apis/cert/crds/cert.gardener.cloud_certificates.yaml
@@ -251,6 +251,14 @@ spec:
               renew:
                 description: Renew triggers a renewal if set to true
                 type: boolean
+              renewBefore:
+                description: |-
+                  RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
+                  Note that the actual expiration of the issued certificate is used for the calculation.
+                  If not set, the default renewal window is used.
+                  Must be at least 5 minutes and less than the renewal window.
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                type: string
               secretLabels:
                 additionalProperties:
                   type: string
@@ -409,6 +417,10 @@ spec:
                   spec.
                 format: int64
                 type: integer
+              renewalDate:
+                description: RenewalDate shows the planned renewal date. If not set,
+                  no renewal has been planned yet.
+                type: string
               state:
                 description: State is the certificate state.
                 type: string

--- a/pkg/apis/cert/crds/zz_generated_crds.go
+++ b/pkg/apis/cert/crds/zz_generated_crds.go
@@ -560,7 +560,7 @@ spec:
                   RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
                   Note that the actual expiration of the issued certificate is used for the calculation.
                   If not set, the default renewal window is used.
-                  Must be at least 5 minutes and less than the renewal window.
+                  Must be at least 5 minutes and not greater than issued certificate's duration minus 5 minutes.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               secretLabels:

--- a/pkg/apis/cert/crds/zz_generated_crds.go
+++ b/pkg/apis/cert/crds/zz_generated_crds.go
@@ -555,6 +555,14 @@ spec:
               renew:
                 description: Renew triggers a renewal if set to true
                 type: boolean
+              renewBefore:
+                description: |-
+                  RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
+                  Note that the actual expiration of the issued certificate is used for the calculation.
+                  If not set, the default renewal window is used.
+                  Must be at least 5 minutes and less than the renewal window.
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                type: string
               secretLabels:
                 additionalProperties:
                   type: string
@@ -713,6 +721,10 @@ spec:
                   spec.
                 format: int64
                 type: integer
+              renewalDate:
+                description: RenewalDate shows the planned renewal date. If not set,
+                  no renewal has been planned yet.
+                type: string
               state:
                 description: State is the certificate state.
                 type: string

--- a/pkg/apis/cert/v1alpha1/types.go
+++ b/pkg/apis/cert/v1alpha1/types.go
@@ -83,7 +83,7 @@ type CertificateSpec struct {
 	// RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
 	// Note that the actual expiration of the issued certificate is used for the calculation.
 	// If not set, the default renewal window is used.
-	// Must be at least 5 minutes and less than the renewal window.
+	// Must be at least 5 minutes and not greater than issued certificate's duration minus 5 minutes.
 	// Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
 	// +optional
 	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`

--- a/pkg/apis/cert/v1alpha1/types.go
+++ b/pkg/apis/cert/v1alpha1/types.go
@@ -80,6 +80,13 @@ type CertificateSpec struct {
 	// Renew triggers a renewal if set to true
 	// +optional
 	Renew *bool `json:"renew,omitempty"`
+	// RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
+	// Note that the actual expiration of the issued certificate is used for the calculation.
+	// If not set, the default renewal window is used.
+	// Must be at least 5 minutes and less than the renewal window.
+	// Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+	// +optional
+	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`
 	// EnsureRenewedAfter specifies a time stamp in the past. Renewing is only triggered if certificate notBefore date is before this date.
 	// +optional
 	EnsureRenewedAfter *metav1.Time `json:"ensureRenewedAfter,omitempty"`
@@ -193,6 +200,9 @@ type CertificateStatus struct {
 	// IssuanceDate shows the notBefore validity date.
 	// +optional
 	IssuanceDate *string `json:"issuanceDate,omitempty"`
+	// RenewalDate shows the planned renewal date. If not set, no renewal has been planned yet.
+	// +optional
+	RenewalDate *string `json:"renewalDate,omitempty"`
 	// ExpirationDate shows the notAfter validity date.
 	// +optional
 	ExpirationDate *string `json:"expirationDate,omitempty"`

--- a/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cert/v1alpha1/zz_generated.deepcopy.go
@@ -444,6 +444,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RenewBefore != nil {
+		in, out := &in.RenewBefore, &out.RenewBefore
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.EnsureRenewedAfter != nil {
 		in, out := &in.EnsureRenewedAfter, &out.EnsureRenewedAfter
 		*out = (*in).DeepCopy()
@@ -520,6 +525,11 @@ func (in *CertificateStatus) DeepCopyInto(out *CertificateStatus) {
 	}
 	if in.IssuanceDate != nil {
 		in, out := &in.IssuanceDate, &out.IssuanceDate
+		*out = new(string)
+		**out = **in
+	}
+	if in.RenewalDate != nil {
+		in, out := &in.RenewalDate, &out.RenewalDate
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
+++ b/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
@@ -256,7 +256,7 @@ spec:
                   RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
                   Note that the actual expiration of the issued certificate is used for the calculation.
                   If not set, the default renewal window is used.
-                  Must be at least 5 minutes and less than the renewal window.
+                  Must be at least 5 minutes and not greater than issued certificate's duration minus 5 minutes.
                   Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
                 type: string
               secretLabels:

--- a/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
+++ b/pkg/certman2/apis/cert/crd-cert.gardener.cloud_certificates.yaml
@@ -251,6 +251,14 @@ spec:
               renew:
                 description: Renew triggers a renewal if set to true
                 type: boolean
+              renewBefore:
+                description: |-
+                  RenewBefore specifies the time before the certificate's expiration date when the certificate should be renewed.
+                  Note that the actual expiration of the issued certificate is used for the calculation.
+                  If not set, the default renewal window is used.
+                  Must be at least 5 minutes and less than the renewal window.
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                type: string
               secretLabels:
                 additionalProperties:
                   type: string
@@ -409,6 +417,10 @@ spec:
                   spec.
                 format: int64
                 type: integer
+              renewalDate:
+                description: RenewalDate shows the planned renewal date. If not set,
+                  no renewal has been planned yet.
+                type: string
               state:
                 description: State is the certificate state.
                 type: string

--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -285,6 +285,7 @@ func (r *certReconciler) reconcileCert(logctx logger.LogContext, obj resources.O
 		status, remove := r.handleObtainOutput(logctx, obj, result)
 		if remove {
 			r.pendingResults.Remove(client.ObjectKeyFromObject(cert))
+			r.support.RemoveScheduledReconciliation(cert)
 		}
 		return status
 	}
@@ -925,6 +926,10 @@ func (r *certReconciler) checkForRenewAndSucceeded(logctx logger.LogContext, obj
 		logctx.Errorf("certificate secret cannot be decoded: %s", err)
 	}
 
+	if status := r.checkScheduledRenewal(logctx, obj, cert); status != nil {
+		return *status
+	}
+
 	revoked := false
 	if _, ok := resources.GetAnnotation(secret, AnnotationRevoked); ok {
 		revoked = true
@@ -938,7 +943,7 @@ func (r *certReconciler) checkForRenewAndSucceeded(logctx logger.LogContext, obj
 		r.support.ClearCertRenewalOverdue(obj.ObjectName())
 	}
 	requestedAt := ExtractRequestedAtFromAnnotation(secret)
-	if cert == nil || r.explicitRenewalRequested(cert, requestedAt, crt.Spec.EnsureRenewedAfter) || !revoked && r.needsRenewal(cert) {
+	if cert == nil || r.explicitRenewalRequested(cert, requestedAt, crt.Spec.EnsureRenewedAfter) || !revoked && r.needsRenewal(cert, &crt.Spec) {
 		if crt.Status.State == api.StatePending && r.lastPendingRateLimiting(crt.Status.LastPendingTimestamp) {
 			return reconcile.Succeeded(logctx)
 		}
@@ -956,6 +961,48 @@ func (r *certReconciler) checkForRenewAndSucceeded(logctx logger.LogContext, obj
 		return r.failed(logctx, obj, api.StateError, err)
 	}
 	return r.succeeded(logctx, obj, &msg)
+}
+
+func (r *certReconciler) checkScheduledRenewal(logctx logger.LogContext, obj resources.Object, cert *x509.Certificate) *reconcile.Status {
+	crt := obj.Data().(*api.Certificate)
+
+	renewalWindow := r.renewalWindow
+	renewBefore := crt.Spec.RenewBefore
+	if renewBefore != nil {
+		if err := r.validateRenewBefore(renewBefore.Duration); err != nil {
+			status := r.failed(logctx, obj, api.StateError, err)
+			return &status
+		}
+		renewalWindow = renewBefore.Duration
+	}
+
+	renewalDate := cert.NotAfter.Add(-renewalWindow)
+	renewalDateFormatted := ptr.To(renewalDate.Format(time.RFC3339))
+	if !ptr.Equal(renewalDateFormatted, crt.Status.RenewalDate) {
+		crt.Status.RenewalDate = renewalDateFormatted
+		if err := obj.UpdateStatus(); err != nil {
+			status := r.failed(logctx, obj, api.StateError, fmt.Errorf("updating renewal date: %w", err))
+			return &status
+		}
+	}
+
+	if !r.support.HasScheduledReconciliation(crt, renewalDate) && !r.needsRenewal(cert, &crt.Spec) {
+		status := reconcile.RescheduleAfter(logctx, time.Until(renewalDate))
+		r.support.AddScheduledReconciliation(crt, renewalDate)
+		return &status
+	}
+
+	return nil
+}
+
+func (r *certReconciler) validateRenewBefore(renewBefore time.Duration) error {
+	if renewBefore < 5*time.Minute {
+		return fmt.Errorf("renewBefore must be at least 5 minutes (%v)", renewBefore)
+	}
+	if renewBefore >= r.renewalWindow {
+		return fmt.Errorf("renewBefore must be less than the renewal window (%v)", r.renewalWindow)
+	}
+	return nil
 }
 
 func (r *certReconciler) updateNotAfterAnnotation(logctx logger.LogContext, obj resources.Object, notAfter time.Time) *reconcile.Status {
@@ -1036,8 +1083,12 @@ func (r *certReconciler) explicitRenewalRequested(cert *x509.Certificate, reques
 	return ensureRenewalAfter != nil && WasRequestedBefore(cert, requestedAt, ensureRenewalAfter.Time)
 }
 
-func (r *certReconciler) needsRenewal(cert *x509.Certificate) bool {
-	return cert.NotAfter.Before(time.Now().Add(r.renewalWindow))
+func (r *certReconciler) needsRenewal(cert *x509.Certificate, crt *api.CertificateSpec) bool {
+	renewalWindow := r.renewalWindow
+	if crt.RenewBefore != nil {
+		renewalWindow = crt.RenewBefore.Duration
+	}
+	return cert.NotAfter.Before(time.Now().Add(renewalWindow))
 }
 
 func (r *certReconciler) isRenewalOverdue(cert *x509.Certificate) bool {
@@ -1096,7 +1147,7 @@ func (r *certReconciler) findSecretByHashLabel(namespace string, spec *api.Certi
 		}
 
 		requestedAt := ExtractRequestedAtFromAnnotation(secret)
-		if !r.needsRenewal(cert) && !r.explicitRenewalRequested(cert, requestedAt, spec.EnsureRenewedAfter) {
+		if !r.needsRenewal(cert, spec) && !r.explicitRenewalRequested(cert, requestedAt, spec.EnsureRenewedAfter) {
 			if best == nil ||
 				bestNotAfter.Before(cert.NotAfter) ||
 				secretRef != nil && bestNotAfter.Equal(cert.NotAfter) && obj.GetName() == secretRef.Name && core.NormalizeNamespace(obj.GetNamespace()) == core.NormalizeNamespace(secretRef.Namespace) {

--- a/pkg/controller/issuer/core/support.go
+++ b/pkg/controller/issuer/core/support.go
@@ -908,3 +908,18 @@ func (s *Support) toObjectNameSet(keyset utils.IssuerKeySet) resources.ObjectNam
 func issuerKeyToObjectName(k utils.IssuerKey, def string) resources.ObjectName {
 	return resources.NewObjectName(k.NamespaceOrDefault(def), k.Name())
 }
+
+// AddScheduledReconciliation adds a scheduled reconciliation for a certificate using its planned renewal date.
+func (s *Support) AddScheduledReconciliation(cert *api.Certificate, renewalDate time.Time) {
+	s.state.AddScheduledReconciliation(newObjectName(cert.Namespace, cert.Name), renewalDate)
+}
+
+// HasScheduledReconciliation checks for a certificate's scheduled reconciliation using its planned renewal date.
+func (s *Support) HasScheduledReconciliation(cert *api.Certificate, renewalDate time.Time) bool {
+	return s.state.HasScheduledReconciliation(newObjectName(cert.Namespace, cert.Name), renewalDate)
+}
+
+// RemoveScheduledReconciliation removes a scheduled reconciliation for a certificate.
+func (s *Support) RemoveScheduledReconciliation(cert *api.Certificate) {
+	s.state.RemoveScheduledReconciliation(newObjectName(cert.Namespace, cert.Name))
+}

--- a/test/integration/controller/issuer/certificate_test.go
+++ b/test/integration/controller/issuer/certificate_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Certificate controller tests", func() {
 					}).WithTimeout(10 * time.Second).Should(Succeed())
 				},
 				Entry("too short", -1*time.Hour, "renewBefore must be at least 5 minutes"),
-				Entry("too long", 365*24*time.Hour, "renewBefore must be less than the renewal window"),
+				Entry("too long", 365*24*time.Hour, "renewBefore must not be greater than the duration of the issued certificate minus 5 minutes"),
 			)
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task api-change enhancement

**What this PR does / why we need it**:

Introduces new fields in the `Certificate` resource:
* `.spec.renewBefore`
* `.status.renewalDate`

The field `renewBefore` allows controlling the renewal window on the level of the `Certificate`.
It specifies a duration that is subtracted from the issued certificate's expiration date to calculate the renewal date.
The planned renewal date is announced in the status of the `Certificate`.
Even when no `renewBefore` is given, the `.status.renewalDate` field will always be populated.

**Which issue(s) this PR fixes**:

Fixes #492

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Introduced new `Certificate` fields: `.spec.renewBefore`, `.status.renewalDate`. The field `renewBefore` allows specifying whether a `Certificate` should be renewed sooner than the configured renewal window.
```
