### PR TITLE
Allow to request intermediate CA certificates for CA issuers

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -735,9 +735,6 @@ func (r *certReconciler) obtainCertificateSelfSigned(logctx logger.LogContext, o
 
 func (r *certReconciler) obtainCertificateCA(logctx logger.LogContext, obj resources.Object,
 	renew bool, cert *api.Certificate, issuerKey utils.IssuerKey, issuer *api.Issuer) reconcile.Status {
-	if cert.Spec.IsCA != nil {
-		return r.failedStop(logctx, obj, api.StateError, fmt.Errorf("isCA cannot be set for a certificate with issuer of type 'ca'"))
-	}
 	CAKeyPair, err := r.restoreCA(issuerKey, issuer)
 	if err != nil {
 		return r.failed(logctx, obj, api.StateError, err)
@@ -802,7 +799,7 @@ func (r *certReconciler) obtainCertificateCA(logctx logger.LogContext, obj resou
 
 	input := legobridge.ObtainInput{CAKeyPair: CAKeyPair, IssuerKey: issuerKey,
 		CommonName: cert.Spec.CommonName, DNSNames: cert.Spec.DNSNames, EmailAddresses: cert.Spec.EmailAddresses, IPAddresses: ipAddresses, URIs: uris, CSR: cert.Spec.CSR,
-		Callback: callback, Renew: renew, Duration: duration, KeyType: keyType}
+		Callback: callback, Renew: renew, Duration: duration, KeyType: keyType, IsCA: ptr.Deref(cert.Spec.IsCA, false)}
 
 	err = r.obtainer.Obtain(input)
 	if err != nil {

--- a/pkg/shared/legobridge/certificate.go
+++ b/pkg/shared/legobridge/certificate.go
@@ -641,12 +641,12 @@ func newCASignedCertFromInput(input ObtainInput) (*certificate.Resource, error) 
 	if err != nil {
 		return nil, err
 	}
-	return newCASignedCertFromCertReq(csr, input.CAKeyPair, input.Duration)
+	return newCASignedCertFromCertReq(csr, input.IsCA, input.CAKeyPair, input.Duration)
 }
 
 // newCASignedCertFromCertReq returns a new Certificate signed by a CA based on
 // an x509.CertificateRequest and a CA key pair. A private key will be generated.
-func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyPair, duration *time.Duration) (*certificate.Resource, error) {
+func newCASignedCertFromCertReq(csr *x509.CertificateRequest, isCA bool, CAKeyPair *TLSKeyPair, duration *time.Duration) (*certificate.Resource, error) {
 	pubKeySize := pubKeySize(csr.PublicKey)
 	if pubKeySize == 0 {
 		pubKeySize = defaultKeySize(csr.PublicKeyAlgorithm)
@@ -658,7 +658,7 @@ func newCASignedCertFromCertReq(csr *x509.CertificateRequest, CAKeyPair *TLSKeyP
 	if duration == nil {
 		return nil, fmt.Errorf("duration must be set")
 	}
-	return issueSignedCert(csr, false, privKey, privKeyPEM, CAKeyPair, *duration)
+	return issueSignedCert(csr, isCA, privKey, privKeyPEM, CAKeyPair, *duration)
 }
 
 // RevokeCertificate revokes a certificate

--- a/pkg/shared/legobridge/pki.go
+++ b/pkg/shared/legobridge/pki.go
@@ -80,6 +80,9 @@ func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Sig
 		return nil, err
 	}
 
+	// Return chain: leaf certificate + issuer certificate
+	crtPEM = append(crtPEM, issuerPEM.Bytes()...)
+
 	return &certificate.Resource{
 		PrivateKey:        privKeyPEM,
 		Certificate:       crtPEM,
@@ -298,7 +301,6 @@ func newSelfSignedCertInPEMFormat(
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		IsCA:                  true,
 		BasicConstraintsValid: true,
-		MaxPathLen:            0,
 	}
 
 	certDerBytes, _ := x509.CreateCertificate(rand.Reader, &template, &template, certPrivateKey.Public(), certPrivateKey)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`Certificate` with `spec.isCA=true` are now also supported for CA issuers and not only for self-signed issuers. 
This allows to create an intermediate CA certificate and using it another CA issuer.

**Which issue(s) this PR fixes**:
Fixes #586 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Allow to request intermediate CA certificates for CA issuers
```
