### PR TITLE
Switch to OIDC Federation Service instead of GitHub App

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       mode: ${{ inputs.mode }}
       version-commit-callback-action-path: .github/actions/prepare-release
     permissions:
-      contents: read
+      id-token: write
 
   oci-images:
     name: Build OCI-Images

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -10,7 +10,7 @@ jobs:
       mode: snapshot
     secrets: inherit
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
 
@@ -18,7 +18,6 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build
-    secrets: inherit
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    secrets: inherit
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
     with:
@@ -31,5 +32,4 @@ jobs:
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}
-      next-version-callback-action-path:
       slack-channel-id: C9CEBQPGE # #sap-tech-gardener


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Currently, the [Gardener GitHub-Actions App](https://github.com/apps/gardener-github-actions) is used to provide more privileged access than available via the default `GITHUB_TOKEN`, for example to circumvent branch protection rules (GitHub Apps can be configured as bypassers) or cross repository privileges. To prevent sharing the GitHub App secret with each and every repository/workflow which requires usage of it, the [GitHub OIDC Federation Service](https://github.com/gardener/github-oidc-federation) has been developed. In essence, it holds the credentials for a central GitHub App and creates short-lived access tokens with a configured scope based on a centrally configured OIDC configuration. See related changes which have been necessary for this repository:

- https://github.com/gardener/.github-oidc/commit/cdfbef51c0e2b24f818fc637c4d182be4a78f3db

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
