### PR TITLE
Feature/add annotation for renewBefore path on ingress / gateway

### DIFF
--- a/docs/usage/tutorials/gateway-api-gateways.md
+++ b/docs/usage/tutorials/gateway-api-gateways.md
@@ -51,6 +51,7 @@ metadata:
   annotations:
     #cert.gardener.cloud/dnsnames: "*.example.com" # alternative if you want to control the dns names explicitly.
     cert.gardener.cloud/purpose: managed
+    #cert.gardener.cloud/renew-before: "720h"      # optional to specify when to renew the certificate before expiration (default: 720h/30 days, min: 5m, max: duration-5m)
 spec:
   gatewayClassName: istio
   listeners:

--- a/docs/usage/tutorials/istio-gateways.md
+++ b/docs/usage/tutorials/istio-gateways.md
@@ -55,6 +55,7 @@ metadata:
     cert.gardener.cloud/purpose: managed
     #cert.gardener.cloud/dnsnames: "*.example.com"                # alternative if you want to control the dns names explicitly.
     #cert.gardener.cloud/secret-namespace: "istio-system"         # optional to specify the namespace where the certificate secret should be created
+    #cert.gardener.cloud/renew-before: "720h"                     # optional to specify when to renew the certificate before expiration (default: 720h/30 days, min: 5m, max: duration-5m)
 spec:
   selector:
     istio: ingressgateway # use Istio default gateway implementation

--- a/examples/40-ingress-echoheaders.yaml
+++ b/examples/40-ingress-echoheaders.yaml
@@ -19,6 +19,7 @@ metadata:
     #cert.gardener.cloud/private-key-algorithm: ECDSA             # optional to specify algorithm for private key, allowed values are 'RSA' or 'ECDSA'
     #cert.gardener.cloud/private-key-size: "384"                  # optional to specify size of private key, allowed values for RSA are "2048", "3072", "4096" and for ECDSA "256" and "384"
     #cert.gardener.cloud/private-key-encoding: PKCS8              # optional to specify encoding for private key, allowed values are 'PKCS1' (default) or 'PKCS8'
+    #cert.gardener.cloud/renew-before: 720h                       # optional to specify when to renew the certificate before expiration (default: 720h/30 days, min: 5m, max: duration-5m)
     # annotations needed when using DNSRecords
     #cert.gardener.cloud/dnsrecord-provider-type: aws-route53
     #cert.gardener.cloud/dnsrecord-secret-ref: myns/mysecret

--- a/pkg/cert/source/controller.go
+++ b/pkg/cert/source/controller.go
@@ -71,6 +71,11 @@ const (
 	// If unset, the private key will be encoded using the traditional format.
 	AnnotPrivateKeyEncoding = "cert.gardener.cloud/private-key-encoding"
 
+	// AnnotRenewBefore is the annotation key to set the renewBefore duration for a Certificate.
+	// The value should be a valid Go duration string (e.g., "720h", "30d").
+	// If unset, the default value of DefaultRenewBefore (30 days) will be used.
+	AnnotRenewBefore = "cert.gardener.cloud/renew-before"
+
 	// OptClass is the cert-class command line option
 	OptClass = "cert-class"
 	// OptTargetclass is the target-cert-class command line option
@@ -82,6 +87,9 @@ const (
 
 	// DefaultClass is the default cert-class
 	DefaultClass = "gardencert"
+
+	// DefaultRenewBefore is the default renewBefore duration (720 hours / 30 days)
+	DefaultRenewBefore = 720 * time.Hour
 )
 
 var certificateGroupKind = resources.NewGroupKind(api.GroupName, api.CertificateKind)

--- a/pkg/cert/source/controller.go
+++ b/pkg/cert/source/controller.go
@@ -72,7 +72,7 @@ const (
 	AnnotPrivateKeyEncoding = "cert.gardener.cloud/private-key-encoding"
 
 	// AnnotRenewBefore is the annotation key to set the renewBefore duration for a Certificate.
-	// The value should be a valid Go duration string (e.g., "720h", "30d").
+	// The value should be a valid Go duration string (e.g., "720h").
 	// If unset, the default of 30 days will be used.
 	AnnotRenewBefore = "cert.gardener.cloud/renew-before"
 

--- a/pkg/cert/source/controller.go
+++ b/pkg/cert/source/controller.go
@@ -73,7 +73,7 @@ const (
 
 	// AnnotRenewBefore is the annotation key to set the renewBefore duration for a Certificate.
 	// The value should be a valid Go duration string (e.g., "720h", "30d").
-	// If unset, the default value of DefaultRenewBefore (30 days) will be used.
+	// If unset, the default of 30 days will be used.
 	AnnotRenewBefore = "cert.gardener.cloud/renew-before"
 
 	// OptClass is the cert-class command line option
@@ -87,9 +87,6 @@ const (
 
 	// DefaultClass is the default cert-class
 	DefaultClass = "gardencert"
-
-	// DefaultRenewBefore is the default renewBefore duration (720 hours / 30 days)
-	DefaultRenewBefore = 720 * time.Hour
 )
 
 var certificateGroupKind = resources.NewGroupKind(api.GroupName, api.CertificateKind)

--- a/pkg/cert/source/interface.go
+++ b/pkg/cert/source/interface.go
@@ -29,6 +29,7 @@ type CertInfo struct {
 	PrivateKeyAlgorithm string
 	PrivateKeySize      api.PrivateKeySize
 	PrivateKeyEncoding  api.PrivateKeyEncoding
+	RenewBefore         *metav1.Duration
 	Annotations         map[string]string
 }
 

--- a/pkg/cert/source/reconciler.go
+++ b/pkg/cert/source/reconciler.go
@@ -362,6 +362,11 @@ func (r *sourceReconciler) createEntryFor(logger logger.LogContext, obj resource
 
 	cert.Spec.PrivateKey = createPrivateKey(info.PrivateKeyAlgorithm, info.PrivateKeySize, info.PrivateKeyEncoding)
 
+	// Set renewBefore (validation will happen in certificate reconciler)
+	if info.RenewBefore != nil {
+		cert.Spec.RenewBefore = info.RenewBefore
+	}
+
 	for key, value := range info.Annotations {
 		resources.SetAnnotation(cert, key, value)
 	}
@@ -471,6 +476,12 @@ func (r *sourceReconciler) updateEntry(logger logger.LogContext, info CertInfo, 
 		newPrivateKey := createPrivateKey(info.PrivateKeyAlgorithm, info.PrivateKeySize, info.PrivateKeyEncoding)
 		if !reflect.DeepEqual(spec.PrivateKey, newPrivateKey) {
 			spec.PrivateKey = newPrivateKey
+			mod.Modify(true)
+		}
+
+		// Update renewBefore (validation will happen in certificate reconciler)
+		if !reflect.DeepEqual(spec.RenewBefore, info.RenewBefore) {
+			spec.RenewBefore = info.RenewBefore
 			mod.Modify(true)
 		}
 

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,6 +32,7 @@ type CertInput struct {
 	PrivateKeyAlgorithm string
 	PrivateKeySize      int
 	PrivateKeyEncoding  string
+	RenewBefore         string
 	Annotations         map[string]string
 }
 
@@ -93,12 +96,15 @@ func augmentFromCommonAnnotations(annotations map[string]string, certInput CertI
 		encoding = v
 	}
 
+	renewBefore := annotations[AnnotRenewBefore]
+
 	certInput.FollowCNAME = followCNAME
 	certInput.IssuerName = issuer
 	certInput.PreferredChain = preferredChain
 	certInput.PrivateKeyAlgorithm = algorithm
 	certInput.PrivateKeySize = keySize
 	certInput.PrivateKeyEncoding = encoding
+	certInput.RenewBefore = renewBefore
 	certInput.SecretLabels = extractSecretLabels(annotations)
 	certInput.Annotations = copyAnnotations(annotations, AnnotClass, AnnotDNSRecordProviderType, AnnotDNSRecordSecretRef)
 	return certInput
@@ -203,6 +209,7 @@ func CreateSpec(src CertInput) certmanv1alpha1.CertificateSpec {
 	}
 
 	spec.PrivateKey = createPrivateKey(src.PrivateKeyAlgorithm, src.PrivateKeySize, src.PrivateKeyEncoding)
+	spec.RenewBefore, _ = ParseRenewBefore(src.RenewBefore)
 
 	return spec
 }
@@ -229,4 +236,26 @@ func normalizeArray(a []string) []string {
 		return nil
 	}
 	return a
+}
+
+// ParseRenewBefore parses the renewBefore duration string and returns a metav1.Duration and an optional warning message.
+// Returns (nil, warning) if the string is invalid or the duration is less than 5 minutes.
+// Returns (nil, "") if the string is empty.
+// The default value of DefaultRenewBefore is applied by the certificate controller if nil is returned.
+func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, string) {
+	if renewBeforeStr == "" {
+		return nil, ""
+	}
+
+	duration, err := time.ParseDuration(renewBeforeStr)
+	if err != nil {
+		return nil, fmt.Sprintf("invalid renew-before annotation value %q: %v", renewBeforeStr, err)
+	}
+
+	// Validate minimum of 5 minutes
+	if duration < 5*time.Minute {
+		return nil, fmt.Sprintf("invalid renew-before annotation value %q: must be at least 5 minutes", renewBeforeStr)
+	}
+
+	return &metav1.Duration{Duration: duration}, ""
 }

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -102,7 +102,7 @@ func augmentFromCommonAnnotations(annotations map[string]string, certInput CertI
 	certInput.PrivateKeyAlgorithm = algorithm
 	certInput.PrivateKeySize = keySize
 	certInput.PrivateKeyEncoding = encoding
-	certInput.RenewBefore, _ = ParseRenewBefore(annotations[AnnotRenewBefore])
+	certInput.RenewBefore, _ = shared.ParseRenewBefore(annotations[AnnotRenewBefore])
 	certInput.SecretLabels = extractSecretLabels(annotations)
 	certInput.Annotations = copyAnnotations(annotations, AnnotClass, AnnotDNSRecordProviderType, AnnotDNSRecordSecretRef)
 	return certInput
@@ -234,12 +234,4 @@ func normalizeArray(a []string) []string {
 		return nil
 	}
 	return a
-}
-
-// ParseRenewBefore parses the renewBefore duration string and returns a *metav1.Duration and an optional error.
-// Returns (nil, error) if the string is invalid or the duration is less than 5 minutes.
-// Returns (nil, nil) if the string is empty.
-// The default of 30 days is applied by the certificate controller if nil is returned.
-func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, error) {
-	return shared.ParseRenewBefore(renewBeforeStr)
 }

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -102,7 +102,7 @@ func augmentFromCommonAnnotations(annotations map[string]string, certInput CertI
 	certInput.PrivateKeyAlgorithm = algorithm
 	certInput.PrivateKeySize = keySize
 	certInput.PrivateKeyEncoding = encoding
-	certInput.RenewBefore = annotations[AnnotRenewBefore]
+	certInput.RenewBefore, _ = ParseRenewBefore(annotations[AnnotRenewBefore])
 	certInput.SecretLabels = extractSecretLabels(annotations)
 	certInput.Annotations = copyAnnotations(annotations, AnnotClass, AnnotDNSRecordProviderType, AnnotDNSRecordSecretRef)
 	return certInput
@@ -207,7 +207,7 @@ func CreateSpec(src CertInput) certmanv1alpha1.CertificateSpec {
 	}
 
 	spec.PrivateKey = createPrivateKey(src.PrivateKeyAlgorithm, src.PrivateKeySize, src.PrivateKeyEncoding)
-	spec.RenewBefore, _ = ParseRenewBefore(src.RenewBefore)
+	spec.RenewBefore = src.RenewBefore
 
 	return spec
 }
@@ -236,24 +236,24 @@ func normalizeArray(a []string) []string {
 	return a
 }
 
-// ParseRenewBefore parses the renewBefore duration string and returns a metav1.Duration and an optional warning message.
-// Returns (nil, warning) if the string is invalid or the duration is less than 5 minutes.
-// Returns (nil, "") if the string is empty.
+// ParseRenewBefore parses the renewBefore duration string and returns a *metav1.Duration and an optional error.
+// Returns (nil, error) if the string is invalid or the duration is less than 5 minutes.
+// Returns (nil, nil) if the string is empty.
 // The default value of DefaultRenewBefore is applied by the certificate controller if nil is returned.
 func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, error) {
 	if renewBeforeStr == "" {
-		return nil, ""
+		return nil, nil
 	}
 
 	duration, err := time.ParseDuration(renewBeforeStr)
 	if err != nil {
-		return nil, fmt.Sprintf("invalid renew-before annotation value %q: %v", renewBeforeStr, err)
+		return nil, fmt.Errorf("invalid renew-before annotation value %q: %w", renewBeforeStr, err)
 	}
 
 	// Validate minimum of 5 minutes
 	if duration < 5*time.Minute {
-		return nil, fmt.Sprintf("invalid renew-before annotation value %q: must be at least 5 minutes", renewBeforeStr)
+		return nil, fmt.Errorf("invalid renew-before annotation value %q: must be at least 5 minutes", renewBeforeStr)
 	}
 
-	return &metav1.Duration{Duration: duration}, ""
+	return &metav1.Duration{Duration: duration}, nil
 }

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -32,7 +32,7 @@ type CertInput struct {
 	PrivateKeyAlgorithm string
 	PrivateKeySize      int
 	PrivateKeyEncoding  string
-	RenewBefore         string
+	RenewBefore         *metav1.Duration
 	Annotations         map[string]string
 }
 

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -240,7 +240,7 @@ func normalizeArray(a []string) []string {
 // Returns (nil, warning) if the string is invalid or the duration is less than 5 minutes.
 // Returns (nil, "") if the string is empty.
 // The default value of DefaultRenewBefore is applied by the certificate controller if nil is returned.
-func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, string) {
+func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, error) {
 	if renewBeforeStr == "" {
 		return nil, ""
 	}

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	certmanv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/shared"
 )
 
 // CertInput contains basic certificate data.
@@ -241,19 +241,5 @@ func normalizeArray(a []string) []string {
 // Returns (nil, nil) if the string is empty.
 // The default value of DefaultRenewBefore is applied by the certificate controller if nil is returned.
 func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, error) {
-	if renewBeforeStr == "" {
-		return nil, nil
-	}
-
-	duration, err := time.ParseDuration(renewBeforeStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid renew-before annotation value %q: %w", renewBeforeStr, err)
-	}
-
-	// Validate minimum of 5 minutes
-	if duration < 5*time.Minute {
-		return nil, fmt.Errorf("invalid renew-before annotation value %q: must be at least 5 minutes", renewBeforeStr)
-	}
-
-	return &metav1.Duration{Duration: duration}, nil
+	return shared.ParseRenewBefore(renewBeforeStr)
 }

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -96,15 +96,13 @@ func augmentFromCommonAnnotations(annotations map[string]string, certInput CertI
 		encoding = v
 	}
 
-	renewBefore := annotations[AnnotRenewBefore]
-
 	certInput.FollowCNAME = followCNAME
 	certInput.IssuerName = issuer
 	certInput.PreferredChain = preferredChain
 	certInput.PrivateKeyAlgorithm = algorithm
 	certInput.PrivateKeySize = keySize
 	certInput.PrivateKeyEncoding = encoding
-	certInput.RenewBefore = renewBefore
+	certInput.RenewBefore = annotations[AnnotRenewBefore]
 	certInput.SecretLabels = extractSecretLabels(annotations)
 	certInput.Annotations = copyAnnotations(annotations, AnnotClass, AnnotDNSRecordProviderType, AnnotDNSRecordSecretRef)
 	return certInput

--- a/pkg/certman2/controller/source/common/certinput.go
+++ b/pkg/certman2/controller/source/common/certinput.go
@@ -239,7 +239,7 @@ func normalizeArray(a []string) []string {
 // ParseRenewBefore parses the renewBefore duration string and returns a *metav1.Duration and an optional error.
 // Returns (nil, error) if the string is invalid or the duration is less than 5 minutes.
 // Returns (nil, nil) if the string is empty.
-// The default value of DefaultRenewBefore is applied by the certificate controller if nil is returned.
+// The default of 30 days is applied by the certificate controller if nil is returned.
 func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, error) {
 	return shared.ParseRenewBefore(renewBeforeStr)
 }

--- a/pkg/certman2/controller/source/common/constants.go
+++ b/pkg/certman2/controller/source/common/constants.go
@@ -51,6 +51,10 @@ const (
 	// If set to `PKCS1`, the private key will be encoded using the traditional format.
 	// If unset, the private key will be encoded using the traditional format.
 	AnnotPrivateKeyEncoding = "cert.gardener.cloud/private-key-encoding"
+	// AnnotRenewBefore is the annotation key to set the renewBefore duration for a Certificate.
+	// The value should be a valid Go duration string (e.g., "720h", "30d").
+	// If unset, the default value of DefaultRenewBefore (30 days) will be used.
+	AnnotRenewBefore = "cert.gardener.cloud/renew-before"
 	// AnnotDNSRecordProviderType is the annotation for providing the provider type for DNS records.
 	AnnotDNSRecordProviderType = "cert.gardener.cloud/dnsrecord-provider-type"
 	// AnnotDNSRecordSecretRef is the annotation for providing the secret ref for DNS records.

--- a/pkg/certman2/controller/source/common/constants.go
+++ b/pkg/certman2/controller/source/common/constants.go
@@ -52,7 +52,7 @@ const (
 	// If unset, the private key will be encoded using the traditional format.
 	AnnotPrivateKeyEncoding = "cert.gardener.cloud/private-key-encoding"
 	// AnnotRenewBefore is the annotation key to set the renewBefore duration for a Certificate.
-	// The value should be a valid Go duration string (e.g., "720h", "30d").
+	// The value should be a valid Go duration string (e.g., "720h").
 	// If unset, the default value of DefaultRenewBefore (30 days) will be used.
 	AnnotRenewBefore = "cert.gardener.cloud/renew-before"
 	// AnnotDNSRecordProviderType is the annotation for providing the provider type for DNS records.

--- a/pkg/certman2/controller/source/common/constants.go
+++ b/pkg/certman2/controller/source/common/constants.go
@@ -53,7 +53,7 @@ const (
 	AnnotPrivateKeyEncoding = "cert.gardener.cloud/private-key-encoding"
 	// AnnotRenewBefore is the annotation key to set the renewBefore duration for a Certificate.
 	// The value should be a valid Go duration string (e.g., "720h").
-	// If unset, the default value of DefaultRenewBefore (30 days) will be used.
+	// If unset, the default of 30 days will be used.
 	AnnotRenewBefore = "cert.gardener.cloud/renew-before"
 	// AnnotDNSRecordProviderType is the annotation for providing the provider type for DNS records.
 	AnnotDNSRecordProviderType = "cert.gardener.cloud/dnsrecord-provider-type"

--- a/pkg/certman2/testutils/assert_events_test.go
+++ b/pkg/certman2/testutils/assert_events_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/cert-management/pkg/certman2/controller/source/common"
+)
+
+func TestTestutils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testutils Suite")
+}
+
+var _ = Describe("ParseRenewBefore", func() {
+	Context("when the input is empty", func() {
+		It("returns nil and no error", func() {
+			result, err := common.ParseRenewBefore("")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Context("when the input is a valid duration", func() {
+		It("parses a duration expressed in hours", func() {
+			result, err := common.ParseRenewBefore("720h")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&metav1.Duration{Duration: 720 * time.Hour}))
+		})
+
+		It("parses the minimum allowed duration of exactly 5 minutes", func() {
+			result, err := common.ParseRenewBefore("5m")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&metav1.Duration{Duration: 5 * time.Minute}))
+		})
+
+		It("parses a duration expressed in minutes greater than 5", func() {
+			result, err := common.ParseRenewBefore("30m")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&metav1.Duration{Duration: 30 * time.Minute}))
+		})
+
+		It("parses a combined hours and minutes duration", func() {
+			result, err := common.ParseRenewBefore("2h30m")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&metav1.Duration{Duration: 2*time.Hour + 30*time.Minute}))
+		})
+
+		It("parses a duration expressed in seconds that equals exactly 5 minutes", func() {
+			result, err := common.ParseRenewBefore("300s")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&metav1.Duration{Duration: 300 * time.Second}))
+		})
+	})
+
+	Context("when the input is an invalid duration string", func() {
+		It("returns nil and an error for a completely invalid string", func() {
+			result, err := common.ParseRenewBefore("not-a-duration")
+			Expect(result).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid renew-before annotation value"))
+			Expect(err.Error()).To(ContainSubstring("not-a-duration"))
+		})
+
+		It("returns nil and an error for a bare number without a unit", func() {
+			result, err := common.ParseRenewBefore("300")
+			Expect(result).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid renew-before annotation value"))
+			Expect(err.Error()).To(ContainSubstring("300"))
+		})
+	})
+
+	Context("when the duration is below the minimum of 5 minutes", func() {
+		It("returns nil and an error for 4 minutes 59 seconds", func() {
+			result, err := common.ParseRenewBefore("4m59s")
+			Expect(result).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))
+		})
+
+		It("returns nil and an error for 1 minute", func() {
+			result, err := common.ParseRenewBefore("1m")
+			Expect(result).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))
+		})
+
+		It("returns nil and an error for 299 seconds", func() {
+			result, err := common.ParseRenewBefore("299s")
+			Expect(result).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))
+		})
+
+		It("returns nil and an error for 0s", func() {
+			result, err := common.ParseRenewBefore("0s")
+			Expect(result).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))
+		})
+	})
+})

--- a/pkg/controller/source/helper.go
+++ b/pkg/controller/source/helper.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/source"
+	"github.com/gardener/cert-management/pkg/certman2/controller/source/common"
 )
 
 const (
@@ -78,6 +80,15 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 		encoding = api.PKCS8
 	}
 
+	var renewBefore *metav1.Duration
+	if renewBeforeStr, ok := resources.GetAnnotation(objData, source.AnnotRenewBefore); ok {
+		var warning string
+		renewBefore, warning = common.ParseRenewBefore(renewBeforeStr)
+		if warning != "" {
+			logger.Warn(warning)
+		}
+	}
+
 	annotatedDomains, cn := source.GetDomainsFromAnnotations(objData, false)
 
 	var issuer *string
@@ -111,6 +122,7 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 			PrivateKeyAlgorithm: algorithm,
 			PrivateKeySize:      keySize,
 			PrivateKeyEncoding:  encoding,
+			RenewBefore:         renewBefore,
 			Annotations:         source.CopyDNSRecordsAnnotations(objData),
 		}
 	}

--- a/pkg/controller/source/helper.go
+++ b/pkg/controller/source/helper.go
@@ -17,7 +17,7 @@ import (
 
 	api "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/gardener/cert-management/pkg/cert/source"
-	"github.com/gardener/cert-management/pkg/certman2/controller/source/common"
+	"github.com/gardener/cert-management/pkg/shared"
 )
 
 const (
@@ -83,7 +83,7 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 	var renewBefore *metav1.Duration
 	if renewBeforeStr, ok := resources.GetAnnotation(objData, source.AnnotRenewBefore); ok {
 		var err error
-		renewBefore, err = common.ParseRenewBefore(renewBeforeStr)
+		renewBefore, err = shared.ParseRenewBefore(renewBeforeStr)
 		if err != nil {
 			logger.Warn(err.Error())
 		}

--- a/pkg/controller/source/helper.go
+++ b/pkg/controller/source/helper.go
@@ -82,10 +82,10 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 
 	var renewBefore *metav1.Duration
 	if renewBeforeStr, ok := resources.GetAnnotation(objData, source.AnnotRenewBefore); ok {
-		var warning string
-		renewBefore, warning = common.ParseRenewBefore(renewBeforeStr)
-		if warning != "" {
-			logger.Warn(warning)
+		var err error
+		renewBefore, err = common.ParseRenewBefore(renewBeforeStr)
+		if err != nil {
+			logger.Warn(err.Error())
 		}
 	}
 

--- a/pkg/shared/annotations.go
+++ b/pkg/shared/annotations.go
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package shared
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ParseRenewBefore parses the renewBefore duration string and returns a *metav1.Duration and an optional error.
+// Returns (nil, error) if the string is invalid or the duration is less than 5 minutes.
+// Returns (nil, nil) if the string is empty.
+// The default value of DefaultRenewBefore is applied by the certificate controller if nil is returned.
+func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, error) {
+	if renewBeforeStr == "" {
+		return nil, nil
+	}
+
+	duration, err := time.ParseDuration(renewBeforeStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid renew-before annotation value %q: %w", renewBeforeStr, err)
+	}
+
+	// Validate minimum of 5 minutes
+	if duration < 5*time.Minute {
+		return nil, fmt.Errorf("invalid renew-before annotation value %q: must be at least 5 minutes", renewBeforeStr)
+	}
+
+	return &metav1.Duration{Duration: duration}, nil
+}

--- a/pkg/shared/annotations.go
+++ b/pkg/shared/annotations.go
@@ -16,7 +16,7 @@ import (
 // ParseRenewBefore parses the renewBefore duration string and returns a *metav1.Duration and an optional error.
 // Returns (nil, error) if the string is invalid or the duration is less than 5 minutes.
 // Returns (nil, nil) if the string is empty.
-// The default value of DefaultRenewBefore is applied by the certificate controller if nil is returned.
+// The default of 30 days is applied by the certificate controller if nil is returned.
 func ParseRenewBefore(renewBeforeStr string) (*metav1.Duration, error) {
 	if renewBeforeStr == "" {
 		return nil, nil

--- a/pkg/shared/annotations_test.go
+++ b/pkg/shared/annotations_test.go
@@ -2,28 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package testutils_test
+package shared_test
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gardener/cert-management/pkg/certman2/controller/source/common"
+	"github.com/gardener/cert-management/pkg/shared"
 )
-
-func TestTestutils(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Testutils Suite")
-}
 
 var _ = Describe("ParseRenewBefore", func() {
 	Context("when the input is empty", func() {
 		It("returns nil and no error", func() {
-			result, err := common.ParseRenewBefore("")
+			result, err := shared.ParseRenewBefore("")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -31,31 +25,31 @@ var _ = Describe("ParseRenewBefore", func() {
 
 	Context("when the input is a valid duration", func() {
 		It("parses a duration expressed in hours", func() {
-			result, err := common.ParseRenewBefore("720h")
+			result, err := shared.ParseRenewBefore("720h")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(&metav1.Duration{Duration: 720 * time.Hour}))
 		})
 
 		It("parses the minimum allowed duration of exactly 5 minutes", func() {
-			result, err := common.ParseRenewBefore("5m")
+			result, err := shared.ParseRenewBefore("5m")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(&metav1.Duration{Duration: 5 * time.Minute}))
 		})
 
 		It("parses a duration expressed in minutes greater than 5", func() {
-			result, err := common.ParseRenewBefore("30m")
+			result, err := shared.ParseRenewBefore("30m")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(&metav1.Duration{Duration: 30 * time.Minute}))
 		})
 
 		It("parses a combined hours and minutes duration", func() {
-			result, err := common.ParseRenewBefore("2h30m")
+			result, err := shared.ParseRenewBefore("2h30m")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(&metav1.Duration{Duration: 2*time.Hour + 30*time.Minute}))
 		})
 
 		It("parses a duration expressed in seconds that equals exactly 5 minutes", func() {
-			result, err := common.ParseRenewBefore("300s")
+			result, err := shared.ParseRenewBefore("300s")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(&metav1.Duration{Duration: 300 * time.Second}))
 		})
@@ -63,7 +57,7 @@ var _ = Describe("ParseRenewBefore", func() {
 
 	Context("when the input is an invalid duration string", func() {
 		It("returns nil and an error for a completely invalid string", func() {
-			result, err := common.ParseRenewBefore("not-a-duration")
+			result, err := shared.ParseRenewBefore("not-a-duration")
 			Expect(result).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid renew-before annotation value"))
@@ -71,7 +65,7 @@ var _ = Describe("ParseRenewBefore", func() {
 		})
 
 		It("returns nil and an error for a bare number without a unit", func() {
-			result, err := common.ParseRenewBefore("300")
+			result, err := shared.ParseRenewBefore("300")
 			Expect(result).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid renew-before annotation value"))
@@ -81,28 +75,28 @@ var _ = Describe("ParseRenewBefore", func() {
 
 	Context("when the duration is below the minimum of 5 minutes", func() {
 		It("returns nil and an error for 4 minutes 59 seconds", func() {
-			result, err := common.ParseRenewBefore("4m59s")
+			result, err := shared.ParseRenewBefore("4m59s")
 			Expect(result).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))
 		})
 
 		It("returns nil and an error for 1 minute", func() {
-			result, err := common.ParseRenewBefore("1m")
+			result, err := shared.ParseRenewBefore("1m")
 			Expect(result).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))
 		})
 
 		It("returns nil and an error for 299 seconds", func() {
-			result, err := common.ParseRenewBefore("299s")
+			result, err := shared.ParseRenewBefore("299s")
 			Expect(result).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))
 		})
 
 		It("returns nil and an error for 0s", func() {
-			result, err := common.ParseRenewBefore("0s")
+			result, err := shared.ParseRenewBefore("0s")
 			Expect(result).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("must be at least 5 minutes"))

--- a/test/certman2/integration/controller/source/source_test.go
+++ b/test/certman2/integration/controller/source/source_test.go
@@ -236,6 +236,332 @@ var _ = Describe("Source controller tests", func() {
 		Expect(testClient.Delete(ctx, service)).To(Succeed())
 	})
 
+	It("should successfully reconcile a service with renew-before annotation", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service-renew",
+				Namespace: testRunID,
+				Annotations: map[string]string{
+					common.AnnotSecretname:  "test-service-renew-secret",
+					common.AnnotDnsnames:    "test-renew.example.com",
+					common.AnnotClass:       testRunID,
+					common.AnnotRenewBefore: "888h",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "https",
+						Port: 443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		Expect(testClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(func() {
+			certificateGarbageCollection(service)
+		})
+
+		By("Wait for certificate with renewBefore")
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: &metav1.Duration{Duration: 888 * time.Hour},
+		})
+
+		Expect(testClient.Delete(ctx, service)).To(Succeed())
+	})
+
+	It("should successfully reconcile a service with minimum renewBefore", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service-renew-min",
+				Namespace: testRunID,
+				Annotations: map[string]string{
+					common.AnnotSecretname:  "test-service-renew-min-secret",
+					common.AnnotDnsnames:    "test-renew-min.example.com",
+					common.AnnotClass:       testRunID,
+					common.AnnotRenewBefore: "5m",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "https",
+						Port: 443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		Expect(testClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(func() {
+			certificateGarbageCollection(service)
+		})
+
+		By("Wait for certificate with minimum renewBefore (5 minutes)")
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-min.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-min-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: &metav1.Duration{Duration: 5 * time.Minute},
+		})
+
+		Expect(testClient.Delete(ctx, service)).To(Succeed())
+	})
+
+	It("should use default renewBefore when annotation is below minimum", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service-renew-below-min",
+				Namespace: testRunID,
+				Annotations: map[string]string{
+					common.AnnotSecretname:  "test-service-renew-below-min-secret",
+					common.AnnotDnsnames:    "test-renew-below-min.example.com",
+					common.AnnotClass:       testRunID,
+					common.AnnotRenewBefore: "3m",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "https",
+						Port: 443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		Expect(testClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(func() {
+			certificateGarbageCollection(service)
+		})
+
+		By("Wait for certificate with default renewBefore (below minimum should be ignored)")
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-below-min.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-below-min-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: nil,
+		})
+
+		Expect(testClient.Delete(ctx, service)).To(Succeed())
+	})
+
+	It("should successfully reconcile a service with maximum renewBefore", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service-renew-max",
+				Namespace: testRunID,
+				Annotations: map[string]string{
+					common.AnnotSecretname:  "test-service-renew-max-secret",
+					common.AnnotDnsnames:    "test-renew-max.example.com",
+					common.AnnotClass:       testRunID,
+					common.AnnotRenewBefore: "8760h",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "https",
+						Port: 443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		Expect(testClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(func() {
+			certificateGarbageCollection(service)
+		})
+
+		By("Wait for certificate with maximum renewBefore (1 year)")
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-max.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-max-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: &metav1.Duration{Duration: 8760 * time.Hour},
+		})
+
+		Expect(testClient.Delete(ctx, service)).To(Succeed())
+	})
+
+	It("should use default renewBefore when annotation has invalid format", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service-renew-invalid",
+				Namespace: testRunID,
+				Annotations: map[string]string{
+					common.AnnotSecretname:  "test-service-renew-invalid-secret",
+					common.AnnotDnsnames:    "test-renew-invalid.example.com",
+					common.AnnotClass:       testRunID,
+					common.AnnotRenewBefore: "invalid-duration",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "https",
+						Port: 443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		Expect(testClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(func() {
+			certificateGarbageCollection(service)
+		})
+
+		By("Wait for certificate with default renewBefore (invalid format should be ignored)")
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-invalid.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-invalid-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: nil,
+		})
+
+		Expect(testClient.Delete(ctx, service)).To(Succeed())
+	})
+
+	It("should use default renewBefore when annotation is empty", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service-renew-default",
+				Namespace: testRunID,
+				Annotations: map[string]string{
+					common.AnnotSecretname: "test-service-renew-default-secret",
+					common.AnnotDnsnames:   "test-renew-default.example.com",
+					common.AnnotClass:      testRunID,
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "https",
+						Port: 443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		Expect(testClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(func() {
+			certificateGarbageCollection(service)
+		})
+
+		By("Wait for certificate with default renewBefore (no annotation)")
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-default.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-default-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: nil,
+		})
+
+		Expect(testClient.Delete(ctx, service)).To(Succeed())
+	})
+
+	It("should update certificate renewBefore when annotation is added, changed, and removed", func() {
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service-renew-update",
+				Namespace: testRunID,
+				Annotations: map[string]string{
+					common.AnnotSecretname: "test-service-renew-update-secret",
+					common.AnnotDnsnames:   "test-renew-update.example.com",
+					common.AnnotClass:      testRunID,
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "https",
+						Port: 443,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		Expect(testClient.Create(ctx, service)).To(Succeed())
+		DeferCleanup(func() {
+			certificateGarbageCollection(service)
+		})
+
+		By("Wait for initial certificate without renewBefore")
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-update.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-update-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: nil,
+		})
+
+		By("Add renew-before annotation and verify certificate is updated")
+		patch := client.MergeFrom(service.DeepCopy())
+		service.Annotations[common.AnnotRenewBefore] = "600h"
+		Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-update.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-update-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: &metav1.Duration{Duration: 600 * time.Hour},
+		})
+
+		By("Change renew-before annotation value and verify certificate is updated")
+		patch = client.MergeFrom(service.DeepCopy())
+		service.Annotations[common.AnnotRenewBefore] = "720h"
+		Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-update.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-update-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: &metav1.Duration{Duration: 720 * time.Hour},
+		})
+
+		By("Remove renew-before annotation and verify certificate renewBefore is cleared")
+		patch = client.MergeFrom(service.DeepCopy())
+		delete(service.Annotations, common.AnnotRenewBefore)
+		Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
+
+		checkCertificateSpec(service, certmanv1alpha1.CertificateSpec{
+			CommonName: ptr.To("test-renew-update.example.com"),
+			SecretRef: &corev1.SecretReference{
+				Name:      "test-service-renew-update-secret",
+				Namespace: testRunID,
+			},
+			RenewBefore: nil,
+		})
+
+		Expect(testClient.Delete(ctx, service)).To(Succeed())
+	})
+
 	It("should successfully reconcile an ingress", func() {
 		ingress := &networkingv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/functional/basics.go
+++ b/test/functional/basics.go
@@ -111,6 +111,17 @@ spec:
 apiVersion: cert.gardener.cloud/v1alpha1
 kind: Certificate
 metadata:
+  name: cert2c
+  namespace: {{.Namespace}}
+spec:
+  commonName: cert2c.{{.Domain}}
+  issuerRef:
+    name: {{.Name}}
+  renewBefore: 840h # 35 days
+---
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: Certificate
+metadata:
   name: cert3
   namespace: {{.Namespace}}
 spec:
@@ -226,6 +237,19 @@ spec:
     namespace: {{.Namespace}}
 `
 
+var revoke2cTemplate = `
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: CertificateRevocation
+metadata:
+  name: revoke-cert2c
+  namespace: {{.Namespace}}
+spec:
+  certificateRef:
+    name: cert2c
+    namespace: {{.Namespace}}
+  renew: true
+`
+
 var revoke3Template = `
 apiVersion: cert.gardener.cloud/v1alpha1
 kind: CertificateRevocation
@@ -304,7 +328,7 @@ func functestbasics(cfg *config.Config, iss *config.IssuerConfig) {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			entryNames := []string{}
-			for _, name := range []string{"1", "2", "2b", "3", "5", "6", "7", "8", "9"} {
+			for _, name := range []string{"1", "2", "2b", "2c", "3", "5", "6", "7", "8", "9"} {
 				entryNames = append(entryNames, entryName(iss, name))
 			}
 			err = u.WaitUntilCertReady(ctx, entryNames...)
@@ -348,6 +372,13 @@ func functestbasics(cfg *config.Config, iss *config.IssuerConfig) {
 				entryName(iss, "2b"): MatchFields(IgnoreExtras, Fields{
 					"Status": MatchFields(IgnoreExtras, Fields{
 						"CommonName":     PointTo(Equal(dnsName(iss, "cert2"))),
+						"State":          Equal("Ready"),
+						"ExpirationDate": PointTo(HavePrefix("20")),
+					}),
+				}),
+				entryName(iss, "2c"): MatchFields(IgnoreExtras, Fields{
+					"Status": MatchFields(IgnoreExtras, Fields{
+						"CommonName":     PointTo(Equal(dnsName(iss, "cert2c"))),
 						"State":          Equal("Ready"),
 						"ExpirationDate": PointTo(HavePrefix("20")),
 					}),
@@ -459,6 +490,24 @@ func functestbasics(cfg *config.Config, iss *config.IssuerConfig) {
 			})
 
 			if !iss.SkipRevokeWithRenewal {
+				By("revoking cert2c with renewal (renewBefore test)", func() {
+					filename, err := iss.CreateTempManifest("revoke2c", revoke2cTemplate)
+					defer iss.DeleteTempManifest(filename)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					err = u.KubectlApply(filename)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					err = u.WaitUntilCertRevocationApplied(ctx, "revoke-cert2c")
+					Expect(err).ShouldNot(HaveOccurred())
+
+					err = u.WaitUntilCertReady(ctx, entryName(iss, "2c"))
+					Expect(err).ShouldNot(HaveOccurred())
+
+					err = u.KubectlDelete(filename)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
 				By("revoking with renewal", func() {
 					filename, err := iss.CreateTempManifest("revoke3", revoke3Template)
 					defer iss.DeleteTempManifest(filename)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Partially fix the renew window, we can increase renewBefore from 30days to 60 days.

**Which issue(s) this PR fixes**:
Related to #475 

**Special notes for your reviewer**:
We can use annotation on ingress / gateway resource to define the renewBefore on certificates

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
- category:       feature
- target_group:  operator
