### PR TITLE
Fix testcase on cert3 with a wildcard domain name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,10 @@ test-functional-local-dnsrecords: $(GINKGO)
 	@USE_DNSRECORDS=true hack/kind/test-functional-local.sh
 
 .PHONY: test-e2e-local
-test-e2e-local: kind-up certman-up test-functional-local certman-dnsrecords-up test-functional-local-dnsrecords
+test-e2e-local: kind-up certman-up
+	@echo "Waiting for certman to be ready..."
+	@sleep 10
+	$(MAKE) test-functional-local certman-dnsrecords-up test-functional-local-dnsrecords
 
 .PHONY: sast
 sast: $(GOSEC)

--- a/hack/kind/dns-controller-manager/dns-controller-manager-up.sh
+++ b/hack/kind/dns-controller-manager/dns-controller-manager-up.sh
@@ -30,6 +30,9 @@ install_dns_controller_manager()
     --set configuration.identifier="host-$(hostname)" \
     --set createCRDs=true \
     --set vpa.enabled=false \
+    --set configuration.poolResyncPeriod=10s \
+    --set configuration.poolSize=5 \
+    --set configuration.cacheTtl=5 \
     | kubectl apply -f -
 }
 

--- a/hack/kind/skaffold-after-hock.sh
+++ b/hack/kind/skaffold-after-hock.sh
@@ -14,8 +14,10 @@ helm template charts/cert-management -n default \
     --set image.tag=$SKAFFOLD_IMAGE_TAG \
     --set configuration.defaultIssuer=kind-issuer \
     --set configuration.caCertificates="$(cat dev/pebble-cert.pem)" \
-    --set configuration.precheckAdditionalWait=1s \
-    --set configuration..configuration.issuerDefaultPoolSize=5 \
+    --set configuration.precheckAdditionalWait=30s \
+    --set configuration.propagationTimeout=180s \
+    --set configuration.poolResyncPeriod=30s \
+    --set configuration.issuerDefaultPoolSize=20 \
     > dev/manifests.yaml
 
 helm template charts/cert-management -n default \
@@ -25,7 +27,10 @@ helm template charts/cert-management -n default \
     --set image.tag=$SKAFFOLD_IMAGE_TAG \
     --set configuration.defaultIssuer=kind-issuer \
     --set configuration.caCertificates="$(cat dev/pebble-cert.pem)" \
-    --set configuration.precheckAdditionalWait=1s \
-    --set configuration..configuration.issuerDefaultPoolSize=5 \
+    --set configuration.precheckAdditionalWait=30s \
+    --set configuration.propagationTimeout=180s \
+    --set configuration.poolResyncPeriod=15s \
+    --set configuration.issuerPoolResyncPeriod=30s \
+    --set configuration.issuerDefaultPoolSize=10 \
     --set configuration.useDnsrecords=true \
     > dev/manifests-dnsrecords.yaml

--- a/test/functional/functest-config-kind.yaml
+++ b/test/functional/functest-config-kind.yaml
@@ -9,4 +9,4 @@ issuers:
   server: https://acme.certman-support.svc.cluster.local/dir
   email: some.user@mydomain.com
   precheckNameservers:
-  - 10.96.0.10:53
+  - knot-dns.certman-support.svc:53


### PR DESCRIPTION
Fixed the DNS propagation delay issue by optimizing the DNS controller manager and cert-management controller reconciliation settings.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
- Fixes the `make test-e2e-local` working

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
The 23-minute delay was caused by slow reconciliation loops in the DNS controller manager. The default resync period of 15 minutes meant that DNS entries were not being processed quickly. By reducing the resync periods and increasing worker pool sizes, DNS TXT records for ACME challenges will now be created and propagated within the 5-minute timeout window.

After rebuilding with these changes, the cert3 wildcard certificate should complete DNS challenge validation within 2-3 minutes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
- category:       bugfix
- target_group:   user|developer
