### PR TITLE
[self-signed certificate]: Fix flapping certificate status if certificate contains IPAddresses

### DIFF
--- a/pkg/controller/issuer/certificate/reconciler.go
+++ b/pkg/controller/issuer/certificate/reconciler.go
@@ -383,11 +383,14 @@ func (r *certReconciler) handleObtainOutput(logctx logger.LogContext, obj resour
 	}
 
 	spec := &api.CertificateSpec{
-		CommonName: result.CommonName,
-		DNSNames:   result.DNSNames,
-		CSR:        result.CSR,
-		IssuerRef:  &api.IssuerRef{Name: result.IssuerInfo.Key().Name(), Namespace: result.IssuerInfo.Key().Namespace()},
-		PrivateKey: legobridge.FromKeyType(result.KeyType),
+		CommonName:     result.CommonName,
+		DNSNames:       result.DNSNames,
+		IPAddresses:    cert.Spec.IPAddresses,
+		EmailAddresses: cert.Spec.EmailAddresses,
+		URIs:           cert.Spec.URIs,
+		CSR:            result.CSR,
+		IssuerRef:      &api.IssuerRef{Name: result.IssuerInfo.Key().Name(), Namespace: result.IssuerInfo.Key().Namespace()},
+		PrivateKey:     legobridge.FromKeyType(result.KeyType),
 	}
 	issuerKey := r.support.IssuerClusterObjectKey(cert.Namespace, spec)
 	specHash := r.buildSpecNewHash(spec, issuerKey)

--- a/test/integration/controller/issuer/certificate_test.go
+++ b/test/integration/controller/issuer/certificate_test.go
@@ -420,7 +420,11 @@ var _ = Describe("Certificate controller tests", func() {
 						Duration: &metav1.Duration{
 							Duration: 48 * time.Hour,
 						},
-						CommonName: ptr.To("example.com"),
+						CommonName:     ptr.To("example.com"),
+						DNSNames:       []string{"*.example.com"},
+						EmailAddresses: []string{"admin@example.com"},
+						IPAddresses:    []string{"127.0.0.1"},
+						URIs:           []string{"https://example.com"},
 					},
 				}
 				Expect(testClient.Create(ctx, certificate)).To(Succeed())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
If a self-signed certificate sets `.spec.ipAddresses`, the certificate status is flapping between `Ready` and `Pending`.
Root cause is a mismatching hash, as `.spec.ipAddresses`, `.spec.emailAddresses`, and `.spec.uris` fields are not included in the hash calculation after obtaining the results.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[self-signed certificate]: Fix flapping certificate status if certificate contains IPAddresses
```
