### PR TITLE
Fix: restore CommonName in ACME-issued certificates after lego v5 upgrade

### DIFF
--- a/pkg/shared/legobridge/certificate.go
+++ b/pkg/shared/legobridge/certificate.go
@@ -187,6 +187,7 @@ func obtainForDomains(ctx context.Context, client *lego.Client, domains []string
 		Bundle:                         true,
 		AlwaysDeactivateAuthorizations: input.AlwaysDeactivateAuthorizations,
 		PreferredChain:                 input.PreferredChain,
+		EnableCommonName:               true,
 		PrivateKey:                     privateKey,
 	}
 	if input.PreflightCheck != nil {
@@ -349,6 +350,7 @@ func obtainForCSR(ctx context.Context, client *lego.Client, csr []byte, input Ob
 		Bundle:                         true,
 		AlwaysDeactivateAuthorizations: input.AlwaysDeactivateAuthorizations,
 		PreferredChain:                 input.PreferredChain,
+		EnableCommonName:               true,
 	})
 }
 

--- a/test/integration/controller/issuer/certificate_test.go
+++ b/test/integration/controller/issuer/certificate_test.go
@@ -512,7 +512,8 @@ var _ = Describe("Certificate controller tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Check SANs in the certificate")
-			Expect(parsedCert.DNSNames).To(ConsistOf("example.com", "another.example.com"))
+			Expect(parsedCert.Subject.CommonName).To(Equal("example.com"))
+			Expect(parsedCert.DNSNames).To(ConsistOf("another.example.com", "example.com"))
 			Expect(parsedCert.EmailAddresses).To(ConsistOf("foo@example.com", "bar@example.com"))
 			Expect(parsedCert.IPAddresses).To(ConsistOf(net.ParseIP("1.1.1.1").To4(), net.ParseIP("1.0.0.1").To4()))
 			Expect(parsedCert.URIs).To(ConsistOf(&url.URL{Scheme: "ftp", Host: "ftp.example.com"}, &url.URL{Scheme: "urn", Opaque: "isbn:9780718097914"}))

--- a/test/integration/controller/issuer/issuer_test.go
+++ b/test/integration/controller/issuer/issuer_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Issuer controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(cert), cert)).To(Succeed())
 				g.Expect(cert.Status.ObservedGeneration).To(Equal(cert.Generation))
 				return cert.Status.State
-			}).Should(Equal("Ready"))
+			}).WithPolling(500 * time.Millisecond).WithTimeout(10 * time.Second).Should(Equal("Ready"))
 		}
 	)
 
@@ -116,6 +116,78 @@ var _ = Describe("Issuer controller tests", func() {
 
 			By("Wait for certificate to become ready")
 			checkCertificateStateReady(cert)
+
+			By("Check CN and DNSNames in the issued certificate")
+			parsedCert := parseCertFromSecret(cert)
+			Expect(parsedCert.Subject.CommonName).To(Equal("example.com"))
+			Expect(parsedCert.DNSNames).To(ConsistOf("example.com"))
+		})
+
+		It("should create a certificate from a CSR", func() {
+			By("Create ACME issuer")
+			issuer := getAcmeIssuer(testRunID)
+			Expect(testClient.Create(ctx, issuer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, issuer)).To(Succeed())
+			})
+
+			checkIssuerStateReady(issuer)
+
+			By("Build a CSR with CN=example.com")
+			csrPEM := buildCSR("example.com", []string{"example.com", "another.example.com"})
+
+			By("Create certificate referencing the CSR")
+			cert := &v1alpha1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testRunID,
+					GenerateName: "acme-certificate-csr-",
+				},
+				Spec: v1alpha1.CertificateSpec{
+					CSR: csrPEM,
+					IssuerRef: &v1alpha1.IssuerRef{
+						Namespace: issuer.Namespace,
+						Name:      issuer.Name,
+					},
+				},
+			}
+			Expect(testClient.Create(ctx, cert)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, cert)).To(Succeed())
+			})
+
+			By("Wait for certificate to become ready")
+			checkCertificateStateReady(cert)
+
+			By("Check CN and DNSNames in the issued certificate")
+			parsedCert := parseCertFromSecret(cert)
+			Expect(parsedCert.Subject.CommonName).To(Equal("example.com"))
+			Expect(parsedCert.DNSNames).To(ConsistOf("example.com", "another.example.com"))
+		})
+
+		It("should create a certificate with both CommonName and DNSNames", func() {
+			By("Create ACME issuer")
+			issuer := getAcmeIssuer(testRunID)
+			Expect(testClient.Create(ctx, issuer)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, issuer)).To(Succeed())
+			})
+
+			checkIssuerStateReady(issuer)
+
+			By("Create certificate with CommonName and additional DNSNames")
+			cert := getCertificate(testRunID, "acme-certificate-cn-sans", "example.com", issuer.Namespace, issuer.Name, "another.example.com", "third.example.com")
+			Expect(testClient.Create(ctx, cert)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testClient.Delete(ctx, cert)).To(Succeed())
+			})
+
+			By("Wait for certificate to become ready")
+			checkCertificateStateReady(cert)
+
+			By("Check CN and DNSNames in the issued certificate")
+			parsedCert := parseCertFromSecret(cert)
+			Expect(parsedCert.Subject.CommonName).To(Equal("example.com"))
+			Expect(parsedCert.DNSNames).To(ConsistOf("example.com", "another.example.com", "third.example.com"))
 		})
 
 		It("should reconcile an orphan pending certificate with an ACME issuer", func() {
@@ -668,7 +740,7 @@ func getAcmeIssuer(namespace string) *v1alpha1.Issuer {
 	}
 }
 
-func getCertificate(certificateNamespace, certificateName, commonName, issuerNamespace, issuerName string) *v1alpha1.Certificate {
+func getCertificate(certificateNamespace, certificateName, commonName, issuerNamespace, issuerName string, dnsNames ...string) *v1alpha1.Certificate {
 	return &v1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    certificateNamespace,
@@ -676,12 +748,41 @@ func getCertificate(certificateNamespace, certificateName, commonName, issuerNam
 		},
 		Spec: v1alpha1.CertificateSpec{
 			CommonName: new(commonName),
+			DNSNames:   dnsNames,
 			IssuerRef: &v1alpha1.IssuerRef{
 				Namespace: issuerNamespace,
 				Name:      issuerName,
 			},
 		},
 	}
+}
+
+func buildCSR(commonName string, dnsNames []string) []byte {
+	GinkgoHelper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject:  pkix.Name{CommonName: commonName},
+		DNSNames: dnsNames,
+	}, privateKey)
+	Expect(err).NotTo(HaveOccurred())
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+}
+
+func parseCertFromSecret(cert *v1alpha1.Certificate) *x509.Certificate {
+	GinkgoHelper()
+	Expect(testClient.Get(ctx, client.ObjectKeyFromObject(cert), cert)).To(Succeed())
+	Expect(cert.Spec.SecretRef).NotTo(BeNil())
+	secret := &corev1.Secret{}
+	Expect(testClient.Get(ctx, client.ObjectKey{
+		Namespace: cert.Spec.SecretRef.Namespace,
+		Name:      cert.Spec.SecretRef.Name,
+	}, secret)).To(Succeed())
+	certBlock, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
+	Expect(certBlock).NotTo(BeNil())
+	parsedCert, err := x509.ParseCertificate(certBlock.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+	return parsedCert
 }
 
 func createPemCertificate(privateKey crypto.PrivateKey, pubKey crypto.PublicKey, header string, privateKeyBytes []byte) (map[string][]byte, error) {

--- a/test/utils/pebble.go
+++ b/test/utils/pebble.go
@@ -38,14 +38,17 @@ const (
 )
 
 var (
+	// PromoteCommonName mirrors lego's EnableCommonName so the issued cert carries a CN.
 	profiles = map[string]ca.Profile{
 		"default": {
-			Description:    "The profile you know and love",
-			ValidityPeriod: 7776000,
+			Description:       "The profile you know and love",
+			ValidityPeriod:    7776000,
+			PromoteCommonName: true,
 		},
 		"shortlived": {
-			Description:    "A short-lived cert profile, without actual enforcement",
-			ValidityPeriod: 518400,
+			Description:       "A short-lived cert profile, without actual enforcement",
+			ValidityPeriod:    518400,
+			PromoteCommonName: true,
 		},
 	}
 	caaIdentities = []string{"pebble.letsencrypt.org"}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
## Summary
  
  Re-enables Common Name (CN) population in certificates issued via ACME after the lego v5 upgrade. lego v5 changed the default to omit CN; this PR opts back in via `EnableCommonName: true` on both `ObtainRequest` and `ObtainForCSRRequest`, restoring the pre-v5 behavior expected by existing consumers.

  ## Changes

  - **`pkg/shared/legobridge/certificate.go`**: set `EnableCommonName: true` in `obtainForDomains` and `obtainForCSR`.
  - **`test/utils/pebble.go`**: set `PromoteCommonName: true` on both Pebble profiles so the local ACME CA emits a CN, mirroring the client-side opt-in (test-only).
  - **`test/integration/controller/issuer/issuer_test.go`**: extend ACME tests to assert `Subject.CommonName` and `DNSNames` on the issued cert; add coverage for the CSR path (`obtainForCSR`) and for the "CommonName + extra
   DNSNames" combination. New helpers: `buildCSR`, `parseCertFromSecret`. `getCertificate` gains a variadic `dnsNames` parameter (backward-compatible).
  - **`test/integration/controller/issuer/certificate_test.go`**: tighten the CA-path SAN test with a `Subject.CommonName` assertion.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
ACME-issued certificates now include the correct Subject Common Name again. The recent lego v5 upgrade had silently dropped the CN from issued certificates, breaking consumers that pin to or parse `Subject.CommonName`. The CN is now populated from `spec.commonName` (or the first DNS name when CN is unset and ≤64 characters).
```
