### PR TITLE
Serve complete CA chain in certificates issued by CA issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ metadata:
 type: kubernetes.io/tls
 ```
 
+If the signing CA is an intermediate CA, `tls.crt` may additionally contain the CA's own
+certificate chain (the signing CA certificate first, followed by its issuer(s)). Certificates
+issued by this issuer will then include the full chain in their `tls.crt`, so that TLS clients
+only need to trust the root CA. Self-signed (root) certificates are not included in the chain of
+issued certificates.
+
 Apply the secrets in the cluster and create the issuer,
 for example see [examples/20-issuer-ca.yaml](./examples/20-issuer-ca.yaml)
 

--- a/pkg/shared/legobridge/cakeypair.go
+++ b/pkg/shared/legobridge/cakeypair.go
@@ -21,6 +21,9 @@ import (
 type TLSKeyPair struct {
 	Cert x509.Certificate
 	Key  crypto.Signer
+	// Chain contains the remaining certificates of the CA's own chain, if the
+	// certificate data of the CA secret contained more than one certificate.
+	Chain []x509.Certificate
 }
 
 // CAKeyPairFromSecretData restores a TLSKeyPair from a secret data map.
@@ -29,7 +32,7 @@ func CAKeyPairFromSecretData(data map[string][]byte) (*TLSKeyPair, error) {
 	if !ok {
 		return nil, fmt.Errorf("`%s` data not found in secret", corev1.TLSCertKey)
 	}
-	cert, err := DecodeCertificate(certBytes)
+	certs, err := DecodeCertificates(certBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +46,11 @@ func CAKeyPairFromSecretData(data map[string][]byte) (*TLSKeyPair, error) {
 		return nil, err
 	}
 
-	return &TLSKeyPair{Cert: *cert, Key: key}, nil
+	var chain []x509.Certificate
+	for _, c := range certs[1:] {
+		chain = append(chain, *c)
+	}
+	return &TLSKeyPair{Cert: *certs[0], Key: key, Chain: chain}, nil
 }
 
 // RawCertInfo returns some info from the CA Certificate.

--- a/pkg/shared/legobridge/cakeypair_test.go
+++ b/pkg/shared/legobridge/cakeypair_test.go
@@ -138,3 +138,74 @@ func createCertificate(privKey crypto.PrivateKey, pubKey crypto.PublicKey, heade
 		corev1.TLSPrivateKeyKey: keyPEM,
 	}, nil
 }
+
+var _ = Describe("CAKeyPair chain handling", func() {
+	It("keeps the CA chain from the secret and serves it in issued certificates", func() {
+		By("Creating a root CA")
+		rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).To(Succeed())
+		rootTmpl := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: "test-root-ca"},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().Add(time.Hour * 24 * 365),
+			KeyUsage:              x509.KeyUsageCertSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+		rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, rootKey.Public(), rootKey)
+		Expect(err).To(Succeed())
+		rootCert, err := x509.ParseCertificate(rootDER)
+		Expect(err).To(Succeed())
+
+		By("Creating an intermediate CA signed by the root")
+		intKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).To(Succeed())
+		intTmpl := &x509.Certificate{
+			SerialNumber:          big.NewInt(2),
+			Subject:               pkix.Name{CommonName: "test-intermediate-ca"},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().Add(time.Hour * 24 * 365),
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+		intDER, err := x509.CreateCertificate(rand.Reader, intTmpl, rootCert, intKey.Public(), rootKey)
+		Expect(err).To(Succeed())
+
+		By("Building a CA secret whose tls.crt holds intermediate + root")
+		intPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: intDER})
+		rootPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(intKey)})
+		data := map[string][]byte{
+			corev1.TLSCertKey:       append(append([]byte{}, intPEM...), rootPEM...),
+			corev1.TLSPrivateKeyKey: keyPEM,
+		}
+
+		keyPair, err := CAKeyPairFromSecretData(data)
+		Expect(err).To(Succeed())
+		Expect(keyPair.Cert.Subject.CommonName).To(Equal("test-intermediate-ca"))
+		Expect(keyPair.Chain).To(HaveLen(1))
+		Expect(keyPair.Chain[0].Subject.CommonName).To(Equal("test-root-ca"))
+
+		By("Issuing a certificate from the chained CA key pair")
+		leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).To(Succeed())
+		leafKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(leafKey)})
+		csr := &x509.CertificateRequest{Subject: pkix.Name{CommonName: "server.example.com"}}
+		resource, err := issueSignedCert(csr, false, leafKey, leafKeyPEM, keyPair, time.Hour*24*90)
+		Expect(err).To(Succeed())
+
+		By("Expecting tls.crt to contain leaf + intermediate, excluding the self-signed root")
+		issued, err := DecodeCertificates(resource.Certificate)
+		Expect(err).To(Succeed())
+		Expect(issued).To(HaveLen(2))
+		Expect(issued[0].Subject.CommonName).To(Equal("server.example.com"))
+		Expect(issued[1].Subject.CommonName).To(Equal("test-intermediate-ca"))
+
+		By("Expecting the issuer certificate bundle to carry the signer (chain roots excluded)")
+		issuers, err := DecodeCertificates(resource.IssuerCertificate)
+		Expect(err).To(Succeed())
+		Expect(issuers[0].Subject.CommonName).To(Equal("test-intermediate-ca"))
+	})
+})

--- a/pkg/shared/legobridge/cakeypair_test.go
+++ b/pkg/shared/legobridge/cakeypair_test.go
@@ -79,7 +79,7 @@ var _ = Describe("PKI Helpers", func() {
 			data[corev1.TLSCertKey] = []byte{}
 
 			_, err = CAKeyPairFromSecretData(data)
-			Expect(err).To(MatchError("decoding pem for tls.crt from request secret failed"))
+			Expect(err).To(MatchError("no certificate found in PEM data for tls.crt"))
 		})
 
 		It("returns error if TLSPrivateKeyKey is missing", func() {

--- a/pkg/shared/legobridge/certificate.go
+++ b/pkg/shared/legobridge/certificate.go
@@ -677,7 +677,7 @@ func DecodeCertificates(tlsCrt []byte) ([]*x509.Certificate, error) {
 		certs = append(certs, cert)
 	}
 	if len(certs) == 0 {
-		return nil, fmt.Errorf("decoding pem for %s from request secret failed", corev1.TLSCertKey)
+		return nil, fmt.Errorf("no certificate found in PEM data for %s", corev1.TLSCertKey)
 	}
 	return certs, nil
 }

--- a/pkg/shared/legobridge/certificate.go
+++ b/pkg/shared/legobridge/certificate.go
@@ -656,6 +656,32 @@ func DecodeCertificate(tlsCrt []byte) (*x509.Certificate, error) {
 	return cert, nil
 }
 
+// DecodeCertificates decodes all certificates from the crt byte array.
+// At least one certificate must be present.
+func DecodeCertificates(tlsCrt []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	rest := tlsCrt
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing certificate failed: %w", err)
+		}
+		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("decoding pem for %s from request secret failed", corev1.TLSCertKey)
+	}
+	return certs, nil
+}
+
 // newCASignedCertFromInput returns a new Certificate signed by a CA.
 // An x509.CertificateRequest is created from scratch based on and ObtainInput object
 func newCASignedCertFromInput(input ObtainInput) (*certificate.Resource, error) {

--- a/pkg/shared/legobridge/pki.go
+++ b/pkg/shared/legobridge/pki.go
@@ -69,8 +69,22 @@ func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Sig
 	if err != nil {
 		return nil, err
 	}
+	// Include the remaining certificates of the CA's own chain, so that TLS servers
+	// using the issued certificate present a complete chain up to (but excluding)
+	// the root. Without this, clients trusting only the root cannot build a path
+	// when the signing CA is itself an intermediate.
+	for i := range signerKeyPair.Chain {
+		chainCert := &signerKeyPair.Chain[i]
+		if isSelfSignedCert(chainCert) {
+			// Roots are trust anchors on the client side; serving them is pointless.
+			continue
+		}
+		if err := encodeCertPEM(issuerPEM, chainCert.Raw); err != nil {
+			return nil, err
+		}
+	}
 
-	// Return chain: leaf certificate + issuer certificate
+	// Return chain: leaf certificate + issuer certificate (+ issuer chain)
 	crtPEM = append(crtPEM, issuerPEM.Bytes()...)
 
 	return &certificate.Resource{
@@ -79,6 +93,12 @@ func issueSignedCert(csr *x509.CertificateRequest, isCA bool, privKey crypto.Sig
 		IssuerCertificate: issuerPEM.Bytes(),
 		CSR:               csrPEM,
 	}, nil
+}
+
+// isSelfSignedCert returns true if the certificate is self-signed (subject equals
+// issuer), i.e. typically a root CA certificate.
+func isSelfSignedCert(cert *x509.Certificate) bool {
+	return bytes.Equal(cert.RawSubject, cert.RawIssuer)
 }
 
 func defaultCertificatePrivateKeyDefaults() CertificatePrivateKeyDefaults {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

For CA issuers, the `tls.crt` of the referenced CA secret may contain the CA's own chain — e.g. an intermediate CA certificate followed by its root. Previously `CAKeyPairFromSecretData` decoded only the first certificate and silently discarded the rest, so certificates issued by an intermediate CA were stored with an incomplete chain: since #601, `tls.crt` contains the leaf and its direct signer, but none of the further intermediates.

TLS servers are expected to present the leaf plus all intermediate certificates up to (but not including) the trust anchor (RFC 5246 section 7.4.2, RFC 8446 section 4.4.2). With an incomplete chain, clients that only trust the root CA fail certification path building (`NET::ERR_CERT_AUTHORITY_INVALID` in browsers). This is particularly painful in air-gapped environments — the primary audience of the CA issuer per the README ("a CA or an intermediate CA ... mainly used for on-premises and air-gapped environments") — where clients cannot fall back to AIA fetching to complete the chain themselves.

This PR completes the chain handling started in #601:

* `DecodeCertificates` (new helper) parses all certificates from a PEM bundle.
* `TLSKeyPair` gains a `Chain` field; `CAKeyPairFromSecretData` keeps the first certificate as the signer and the remaining certificates as its chain.
* `issueSignedCert` appends the signer's chain to both the issued certificate (`tls.crt`) and the issuer bundle. Self-signed (root) certificates in the chain are excluded — they are trust anchors on the client side and serving them is unnecessary.

Behavior is unchanged for CA secrets containing a single certificate, i.e. for the self-signed root CA flow shown in the README.

**Which issue(s) this PR fixes**:
None (no open issue). Related: #586 / #601, which introduced the leaf+signer concatenation this PR completes for multi-level CA hierarchies.

**Special notes for your reviewer**:
The new test in `cakeypair_test.go` builds a root → intermediate → leaf hierarchy, stores intermediate+root in the CA secret, and asserts that the issued `tls.crt` contains exactly leaf + intermediate (root excluded).

**Release note**:
```bugfix user
Certificates issued by CA issuers now include the CA's full chain in `tls.crt` when the issuer's CA secret contains a certificate chain (e.g. an intermediate CA and its root). Self-signed root certificates are excluded from the served chain.
```
