### PR TITLE
Include the common name in the SANs of certificates issued by CA issuers

### DIFF
--- a/pkg/shared/legobridge/pki.go
+++ b/pkg/shared/legobridge/pki.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -146,6 +147,19 @@ func createCertReq(input ObtainInput) (*x509.CertificateRequest, error) {
 	emailAddresses = append(emailAddresses, input.CAKeyPair.Cert.EmailAddresses...)
 	emailAddresses = append(emailAddresses, input.EmailAddresses...)
 
+	// For leaf certificates, ensure the common name is also present as a DNS SAN.
+	// Modern TLS clients ignore the certificate's common name and validate the
+	// requested hostname only against the subject alternative names; a Certificate
+	// that sets only `commonName` (and no `dnsNames`) would otherwise yield a
+	// certificate that browsers reject with ERR_CERT_COMMON_NAME_INVALID. This
+	// matches the ACME issuance path, which already includes the common name in the
+	// set of domains. CA certificates are excluded: their common name is an
+	// identity, not a hostname.
+	dnsNames := input.DNSNames
+	if !input.IsCA && input.CommonName != nil && *input.CommonName != "" && !slices.Contains(dnsNames, *input.CommonName) {
+		dnsNames = append([]string{*input.CommonName}, dnsNames...)
+	}
+
 	return &x509.CertificateRequest{
 		Version:            3,
 		PublicKeyAlgorithm: getPublicKeyAlgorithm(privateKey),
@@ -160,7 +174,7 @@ func createCertReq(input ObtainInput) (*x509.CertificateRequest, error) {
 			StreetAddress:      subjectCA.StreetAddress,
 			PostalCode:         subjectCA.PostalCode,
 		},
-		DNSNames:       input.DNSNames,
+		DNSNames:       dnsNames,
 		EmailAddresses: emailAddresses,
 		IPAddresses:    input.IPAddresses,
 		URIs:           input.URIs,

--- a/pkg/shared/legobridge/pki_test.go
+++ b/pkg/shared/legobridge/pki_test.go
@@ -84,6 +84,42 @@ var _ = Describe("PKI", func() {
 		)
 	})
 
+	Context("#createCertReq", func() {
+		baseInput := func() ObtainInput {
+			return ObtainInput{
+				CAKeyPair: &TLSKeyPair{Cert: x509.Certificate{}},
+				KeySpec:   KeySpec{KeyType: RSA2048},
+			}
+		}
+
+		It("adds the common name as a DNS SAN for leaf certificates", func() {
+			input := baseInput()
+			input.CommonName = new("*.ingress.example.com")
+			csr, err := createCertReq(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(csr.Subject.CommonName).To(Equal("*.ingress.example.com"))
+			Expect(csr.DNSNames).To(ConsistOf("*.ingress.example.com"))
+		})
+
+		It("prepends the common name without duplicating an existing DNS name", func() {
+			input := baseInput()
+			input.CommonName = new("a.example.com")
+			input.DNSNames = []string{"b.example.com", "a.example.com"}
+			csr, err := createCertReq(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(csr.DNSNames).To(Equal([]string{"b.example.com", "a.example.com"}))
+		})
+
+		It("does not add the common name as a SAN for CA certificates", func() {
+			input := baseInput()
+			input.CommonName = new("Intermediate CA")
+			input.IsCA = true
+			csr, err := createCertReq(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(csr.DNSNames).To(BeEmpty())
+		})
+	})
+
 	Context("#GenerateKeyFromSpec", func() {
 		DescribeTable("should generate a private key of the expected type and size",
 			func(keyType KeyType, usePKCS8 bool, expectedKeySize int) {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

For CA issuers, a `Certificate` that sets only `spec.commonName` (and no `spec.dnsNames`) is issued with the common name in the subject, but with **no subject alternative names**. Modern TLS clients (browsers since ~2017, per the CA/Browser Forum baseline requirements and RFC 2818) ignore the certificate's common name entirely and validate the requested hostname only against the SANs. Such a certificate is therefore rejected — e.g. Chrome reports `ERR_CERT_COMMON_NAME_INVALID` — even though the hostname matches the common name.

The ACME issuance path is not affected: it already includes the common name in the set of requested domains (`obtainForDomains` prepends `CommonName` to `DNSNames`), so ACME-issued certificates carry the common name as a SAN. The CA issuance path (`createCertReq`) does not do this — it copies `input.DNSNames` verbatim into the CSR — so the two paths diverge.

This PR restores parity: `createCertReq` now includes the common name in the CSR's DNS SANs for leaf certificates (deduplicated, and only when a common name is set). CA certificates (`isCA: true`) are intentionally excluded, since their common name is an identity rather than a hostname.

Behavior is unchanged for certificates that already set `dnsNames`, or whose common name is already present in `dnsNames`.

**Which issue(s) this PR fixes**:
None (no open issue).

**Special notes for your reviewer**:
New unit tests on `createCertReq` cover the three cases: common name added as a SAN for a leaf, no duplication when the common name is already in `dnsNames`, and no SAN added for a CA certificate.

**Release note**:
```bugfix user
Certificates issued by CA issuers now include the common name in the subject alternative names (SANs), matching the behavior of the ACME issuer. This fixes certificates that specify only `commonName` (and no `dnsNames`) being rejected by clients that validate the hostname against SANs only.
```
