### PR TITLE
Remove outdated CSR warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,8 +546,6 @@ spec:
     name: issuer-staging
 ```
 
-:warning: Using a CSR is only available for ACME Issuer
-
 ### Creating JKS or PKCS#12 keystores
 
 By default, the certificate secret contains the TLS certificate using the standard


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

The warning that CSR is only supported for ACME `Issuer`s is outdated. It works for CA and self-signed too.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**CSR handled in:**
* ACME flow: https://github.com/gardener/cert-management/blob/cfc5e6f381966c46bccc3b24e0e84016e9342531/pkg/controller/issuer/certificate/reconciler.go#L607
* Self-signed flow: https://github.com/gardener/cert-management/blob/cfc5e6f381966c46bccc3b24e0e84016e9342531/pkg/controller/issuer/certificate/reconciler.go#L744 
* CA flow: https://github.com/gardener/cert-management/blob/cfc5e6f381966c46bccc3b24e0e84016e9342531/pkg/controller/issuer/certificate/reconciler.go#L822

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
