### PR TITLE
Assign HTTPRoute hosts to matching listener by section name

### DIFF
--- a/pkg/certman2/controller/source/common/certinput_collector.go
+++ b/pkg/certman2/controller/source/common/certinput_collector.go
@@ -24,6 +24,7 @@ type TLSData struct {
 	SecretNamespace string
 	SecretName      string
 	Hosts           []string
+	SectionName     string
 }
 
 // GetCertInputByCollector collects data from annotations and from the resources needed for creating certificates.
@@ -56,12 +57,35 @@ func GetCertInputByCollector(ctx context.Context, log logr.Logger, obj client.Ob
 			domains = mergeCommonName(cn, tls.Hosts)
 		}
 		key := client.ObjectKey{Namespace: tls.SecretNamespace, Name: tls.SecretName}
+		if existing, ok := inputMap[key]; ok {
+			// Multiple listeners may reference the same certificate secret (e.g. distinct
+			// listener section names sharing one certificateRef). Merge their domains instead
+			// of overwriting, so no host is silently dropped.
+			existing.Domains = mergeDomains(existing.Domains, domains)
+			inputMap[key] = existing
+			continue
+		}
 		inputMap[key] = augmentFromCommonAnnotations(obj.GetAnnotations(), CertInput{
 			SecretObjectKey: key,
 			Domains:         domains,
 		})
 	}
 	return inputMap, err
+}
+
+// mergeDomains appends domains from add that are not already present in base, preserving order.
+func mergeDomains(base, add []string) []string {
+	seen := make(map[string]struct{}, len(base))
+	for _, d := range base {
+		seen[d] = struct{}{}
+	}
+	for _, d := range add {
+		if _, ok := seen[d]; !ok {
+			seen[d] = struct{}{}
+			base = append(base, d)
+		}
+	}
+	return base
 }
 
 func mergeCommonName(cn string, hosts []string) []string {

--- a/pkg/certman2/controller/source/k8s_gateway/reconciler_certinputmap_test.go
+++ b/pkg/certman2/controller/source/k8s_gateway/reconciler_certinputmap_test.go
@@ -106,6 +106,63 @@ var _ = Describe("Reconciler", func() {
 			}
 			return []*gatewayapisv1.HTTPRoute{routeExample, routeLegacy}
 		}
+
+		// sectionRoutes returns routes pinned to specific listeners of g1 via ParentRef.SectionName,
+		// plus one route without a section name that contributes to all listeners.
+		sectionRoutes = func() []*gatewayapisv1.HTTPRoute {
+			routeSectionWeb := &gatewayapisv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "route-web"},
+				Spec: gatewayapisv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+						{
+							Namespace:   ptr.To[gatewayapisv1.Namespace]("test"),
+							Name:        "g1",
+							SectionName: ptr.To(gatewayapisv1.SectionName("web")),
+						},
+					}},
+					Hostnames: []gatewayapisv1.Hostname{"api.web.example.com"},
+				},
+			}
+			routeSectionAdmin := &gatewayapisv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "route-admin"},
+				Spec: gatewayapisv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+						{
+							Namespace:   ptr.To[gatewayapisv1.Namespace]("test"),
+							Name:        "g1",
+							SectionName: ptr.To(gatewayapisv1.SectionName("admin")),
+						},
+					}},
+					Hostnames: []gatewayapisv1.Hostname{"api.admin.example.com"},
+				},
+			}
+			routeSectionGeneric := &gatewayapisv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "route-generic"},
+				Spec: gatewayapisv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+						{
+							Namespace:   ptr.To[gatewayapisv1.Namespace]("test"),
+							Name:        "g1",
+							SectionName: ptr.To(gatewayapisv1.SectionName("generic")),
+						},
+					}},
+					Hostnames: []gatewayapisv1.Hostname{"api.generic-example.com", "generic-example.com"},
+				},
+			}
+			routeNoSection := &gatewayapisv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "route-shared"},
+				Spec: gatewayapisv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+						{
+							Namespace: ptr.To[gatewayapisv1.Namespace]("test"),
+							Name:      "g1",
+						},
+					}},
+					Hostnames: []gatewayapisv1.Hostname{"api.shared.example.com"},
+				},
+			}
+			return []*gatewayapisv1.HTTPRoute{routeSectionWeb, routeSectionAdmin, routeSectionGeneric, routeNoSection}
+		}
 	)
 
 	BeforeEach(func() {
@@ -423,6 +480,63 @@ var _ = Describe("Reconciler", func() {
 				},
 			},
 		}, allRoutes(), singleCertInput("cert-example", nil, "foo.example.com", "bar.example.com")),
+		Entry("HTTPRoutes with section name should only add hosts to the matching listener", &gatewayapisv1.Gateway{
+			ObjectMeta: standardObjectMeta,
+			Spec: gatewayapisv1.GatewaySpec{
+				Listeners: []gatewayapisv1.Listener{
+					{
+						Name:     "web",
+						Hostname: ptr.To[gatewayapisv1.Hostname]("*.example.com"),
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-web"}},
+						},
+					},
+					{
+						Name:     "admin",
+						Hostname: ptr.To[gatewayapisv1.Hostname]("*.example.com"),
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-admin"}},
+						},
+					},
+					{
+						Name:     "generic",
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-generic"}},
+						},
+					},
+				},
+			},
+		}, sectionRoutes(), toMap(
+			makeCertInput("cert-web", nil, "*.example.com", "api.shared.example.com", "api.web.example.com"),
+			makeCertInput("cert-admin", nil, "*.example.com", "api.admin.example.com", "api.shared.example.com"),
+			makeCertInput("cert-generic", nil, "api.generic-example.com", "generic-example.com", "api.shared.example.com"),
+		)),
+		Entry("listeners with different section names sharing one certificate secret should merge their hosts", &gatewayapisv1.Gateway{
+			ObjectMeta: standardObjectMeta,
+			Spec: gatewayapisv1.GatewaySpec{
+				Listeners: []gatewayapisv1.Listener{
+					{
+						Name:     "web",
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-shared"}},
+						},
+					},
+					{
+						Name:     "admin",
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-shared"}},
+						},
+					},
+				},
+			},
+		}, sectionRoutes(), toMap(
+			makeCertInput("cert-shared", nil, "api.shared.example.com", "api.web.example.com", "api.admin.example.com"),
+		)),
 	)
 })
 

--- a/pkg/certman2/controller/source/k8s_gateway/reconciler_reconcile.go
+++ b/pkg/certman2/controller/source/k8s_gateway/reconciler_reconcile.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -100,21 +101,26 @@ func (r *Reconciler) getCertificateInputMap(ctx context.Context, log logr.Logger
 			if err != nil {
 				return nil, err
 			}
+			listenerSectionNames := sets.New[string]()
+			for _, item := range array {
+				listenerSectionNames.Insert(item.SectionName)
+			}
 			for _, item := range array {
 				var listenerHost string
 				if len(item.Hosts) > 0 {
 					listenerHost = item.Hosts[0]
 				}
 				gl := gatewayListener{gateway: gatewayKey, listenerSectionName: item.SectionName}
-				item.Hosts = r.appendHostsFromHTTPRoutes(gl, routes, item.Hosts, listenerHost)
+				item.Hosts = r.appendHostsFromHTTPRoutes(log, gl, routes, item.Hosts, listenerHost)
 			}
+			logRoutesWithUnmatchedSection(log, gatewayKey, routes, listenerSectionNames)
 		}
 
 		return array, nil
 	})
 }
 
-func (r *Reconciler) appendHostsFromHTTPRoutes(gl gatewayListener, routes []client.Object, hosts []string, listenerHost string) []string {
+func (r *Reconciler) appendHostsFromHTTPRoutes(log logr.Logger, gl gatewayListener, routes []client.Object, hosts []string, listenerHost string) []string {
 	addHost := func(hosts []string, host string) []string {
 		for _, h := range hosts {
 			if h == host || shared.MatchesWildcardSingleSubdomain(host, h) {
@@ -124,6 +130,9 @@ func (r *Reconciler) appendHostsFromHTTPRoutes(gl gatewayListener, routes []clie
 		if listenerHost != "" {
 			if !shared.MatchesWildcardAnySubdomain(host, listenerHost) && !shared.MatchesWildcardAnySubdomain(listenerHost, host) {
 				// foreign host for another listener, do not add
+				log.V(1).Info("skipping HTTPRoute host: does not match listener hostname",
+					"gateway", gl.gateway, "listenerSectionName", gl.listenerSectionName,
+					"listenerHostname", listenerHost, "host", host)
 				return hosts
 			}
 		}
@@ -147,6 +156,33 @@ func (r *Reconciler) appendHostsFromHTTPRoutes(gl gatewayListener, routes []clie
 		}
 	}
 	return hosts
+}
+
+// logRoutesWithUnmatchedSection warns about HTTPRoutes that reference the gateway with a
+// listener section name that matches none of the gateway's listeners with a TLS certificate.
+// Their hosts are silently dropped from all certificates, which is otherwise hard to debug.
+func logRoutesWithUnmatchedSection(log logr.Logger, gatewayKey client.ObjectKey, routes []client.Object, listenerSectionNames sets.Set[string]) {
+	warn := func(routeParentRefs []gatewayapisv1.ParentReference, routeName string) {
+		for _, ref := range routeParentRefs {
+			if ref.SectionName == nil {
+				continue
+			}
+			if string(ref.Name) == gatewayKey.Name &&
+				(ref.Namespace == nil || string(*ref.Namespace) == gatewayKey.Namespace) &&
+				!listenerSectionNames.Has(string(*ref.SectionName)) {
+				log.V(1).Info("HTTPRoute references a listener section name that matches no TLS listener; its hosts are ignored",
+					"gateway", gatewayKey, "httpRoute", routeName, "sectionName", string(*ref.SectionName))
+			}
+		}
+	}
+	for _, route := range routes {
+		switch r := route.(type) {
+		case *gatewayapisv1.HTTPRoute:
+			warn(r.Spec.ParentRefs, r.Name)
+		case *gatewayapisv1beta1.HTTPRoute:
+			warn(r.Spec.ParentRefs, r.Name)
+		}
+	}
 }
 
 // gatewayListener identifies a specific listener section within a Gateway resource.

--- a/pkg/certman2/controller/source/k8s_gateway/reconciler_reconcile.go
+++ b/pkg/certman2/controller/source/k8s_gateway/reconciler_reconcile.go
@@ -76,7 +76,10 @@ func (r *Reconciler) getCertificateInputMap(ctx context.Context, log logr.Logger
 						if len(ref.Name) == 0 {
 							continue
 						}
-						tlsData := &common.TLSData{SecretName: string(ref.Name)}
+						tlsData := &common.TLSData{
+							SecretName:  string(ref.Name),
+							SectionName: string(listener.Name),
+						}
 						if ref.Namespace != nil {
 							tlsData.SecretNamespace = string(*ref.Namespace)
 						} else {
@@ -92,7 +95,8 @@ func (r *Reconciler) getCertificateInputMap(ctx context.Context, log logr.Logger
 		}
 
 		if len(array) > 0 {
-			routes, err := r.listHTTPRoutes(ctx, new(client.ObjectKeyFromObject(gateway)), r.ActiveVersion)
+			gatewayKey := client.ObjectKeyFromObject(gateway)
+			routes, err := r.listHTTPRoutes(ctx, new(gatewayKey), r.ActiveVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -101,7 +105,8 @@ func (r *Reconciler) getCertificateInputMap(ctx context.Context, log logr.Logger
 				if len(item.Hosts) > 0 {
 					listenerHost = item.Hosts[0]
 				}
-				item.Hosts = r.appendHostsFromHTTPRoutes(routes, item.Hosts, listenerHost)
+				gl := gatewayListener{gateway: gatewayKey, listenerSectionName: item.SectionName}
+				item.Hosts = r.appendHostsFromHTTPRoutes(gl, routes, item.Hosts, listenerHost)
 			}
 		}
 
@@ -109,7 +114,7 @@ func (r *Reconciler) getCertificateInputMap(ctx context.Context, log logr.Logger
 	})
 }
 
-func (r *Reconciler) appendHostsFromHTTPRoutes(routes []client.Object, hosts []string, listenerHost string) []string {
+func (r *Reconciler) appendHostsFromHTTPRoutes(gl gatewayListener, routes []client.Object, hosts []string, listenerHost string) []string {
 	addHost := func(hosts []string, host string) []string {
 		for _, h := range hosts {
 			if h == host || shared.MatchesWildcardSingleSubdomain(host, h) {
@@ -128,16 +133,38 @@ func (r *Reconciler) appendHostsFromHTTPRoutes(routes []client.Object, hosts []s
 	for _, route := range routes {
 		switch r := route.(type) {
 		case *gatewayapisv1.HTTPRoute:
-			for _, h := range r.Spec.Hostnames {
-				hosts = addHost(hosts, string(h))
+			if matchesGatewayListener(r.Spec.ParentRefs, gl) {
+				for _, h := range r.Spec.Hostnames {
+					hosts = addHost(hosts, string(h))
+				}
 			}
 		case *gatewayapisv1beta1.HTTPRoute:
-			for _, h := range r.Spec.Hostnames {
-				hosts = addHost(hosts, string(h))
+			if matchesGatewayListener(r.Spec.ParentRefs, gl) {
+				for _, h := range r.Spec.Hostnames {
+					hosts = addHost(hosts, string(h))
+				}
 			}
 		}
 	}
 	return hosts
+}
+
+// gatewayListener identifies a specific listener section within a Gateway resource.
+type gatewayListener struct {
+	gateway client.ObjectKey
+	// listenerSectionName is an optional field to specify a listener of the gateway.
+	listenerSectionName string
+}
+
+func matchesGatewayListener(parentRefs []gatewayapisv1.ParentReference, gl gatewayListener) bool {
+	for _, ref := range parentRefs {
+		if string(ref.Name) == gl.gateway.Name &&
+			(ref.Namespace == nil || string(*ref.Namespace) == gl.gateway.Namespace) &&
+			(ref.SectionName == nil || gl.listenerSectionName == "" || string(*ref.SectionName) == gl.listenerSectionName) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Reconciler) listHTTPRoutes(ctx context.Context, gatewayKey *client.ObjectKey, version Version) ([]client.Object, error) {

--- a/pkg/controller/source/gateways/gatewayapi/handler.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler.go
@@ -89,7 +89,10 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 						if len(ref.Name) == 0 {
 							continue
 						}
-						tlsData := &ctrlsource.TLSData{SecretName: string(ref.Name)}
+						tlsData := &ctrlsource.TLSData{
+							SecretName:  string(ref.Name),
+							SectionName: string(listener.Name),
+						}
 						if ref.Namespace != nil {
 							ns := string(*ref.Namespace)
 							tlsData.SecretNamespace = &ns
@@ -104,7 +107,8 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 		}
 
 		if len(array) > 0 {
-			routes, err := s.lister.ListHTTPRoutes(new(resources.NewObjectNameForData(objData)))
+			gateway := resources.NewObjectNameForData(objData)
+			routes, err := s.lister.ListHTTPRoutes(new(gateway))
 			if err != nil {
 				return nil, err
 			}
@@ -113,7 +117,7 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 				if len(item.Hosts) > 0 {
 					listenerHost = item.Hosts[0]
 				}
-				item.Hosts = s.appendHostsFromHTTPRoutes(routes, item.Hosts, listenerHost)
+				item.Hosts = s.appendHostsFromHTTPRoutes(gatewayListener{Gateway: gateway, ListenerSectionName: item.SectionName}, routes, item.Hosts, listenerHost)
 			}
 		}
 
@@ -121,7 +125,7 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 	})
 }
 
-func (s *gatewaySource) appendHostsFromHTTPRoutes(routes []resources.ObjectData, hosts []string, listenerHost string) []string {
+func (s *gatewaySource) appendHostsFromHTTPRoutes(gl gatewayListener, routes []resources.ObjectData, hosts []string, listenerHost string) []string {
 	addHost := func(hosts []string, host string) []string {
 		for _, h := range hosts {
 			if h == host || shared.MatchesWildcardSingleSubdomain(host, h) {
@@ -140,16 +144,31 @@ func (s *gatewaySource) appendHostsFromHTTPRoutes(routes []resources.ObjectData,
 	for _, route := range routes {
 		switch r := route.(type) {
 		case *gatewayapisv1.HTTPRoute:
-			for _, h := range r.Spec.Hostnames {
-				hosts = addHost(hosts, string(h))
+			if matchesGatewayListener(r.Spec.ParentRefs, gl) {
+				for _, h := range r.Spec.Hostnames {
+					hosts = addHost(hosts, string(h))
+				}
 			}
 		case *gatewayapisv1beta1.HTTPRoute:
-			for _, h := range r.Spec.Hostnames {
-				hosts = addHost(hosts, string(h))
+			if matchesGatewayListener(r.Spec.ParentRefs, gl) {
+				for _, h := range r.Spec.Hostnames {
+					hosts = addHost(hosts, string(h))
+				}
 			}
 		}
 	}
 	return hosts
+}
+
+func matchesGatewayListener(parentRefs []gatewayapisv1.ParentReference, gl gatewayListener) bool {
+	for _, ref := range parentRefs {
+		if string(ref.Name) == gl.Gateway.Name() &&
+			(ref.Namespace == nil || string(*ref.Namespace) == gl.Gateway.Namespace()) &&
+			(ref.SectionName == nil || gl.ListenerSectionName == "" || string(*ref.SectionName) == gl.ListenerSectionName) {
+			return true
+		}
+	}
+	return false
 }
 
 var _ httpRouteLister = &httprouteLister{}
@@ -173,8 +192,7 @@ func (l *httprouteLister) ListHTTPRoutes(gateway *resources.ObjectName) ([]resou
 	}
 	var array []resources.ObjectData
 	for _, obj := range objs {
-		gateways := extractGatewayNames(obj.Data())
-		for g := range gateways {
+		for g := range extractGatewayNames(obj.Data()) {
 			if gateway == nil || g == *gateway {
 				array = append(array, obj.Data())
 			}

--- a/pkg/controller/source/gateways/gatewayapi/handler.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler.go
@@ -112,20 +112,25 @@ func (s *gatewaySource) GetCertsInfo(logger logger.LogContext, objData resources
 			if err != nil {
 				return nil, err
 			}
+			listenerSectionNames := map[string]struct{}{}
+			for _, item := range array {
+				listenerSectionNames[item.SectionName] = struct{}{}
+			}
 			for _, item := range array {
 				var listenerHost string
 				if len(item.Hosts) > 0 {
 					listenerHost = item.Hosts[0]
 				}
-				item.Hosts = s.appendHostsFromHTTPRoutes(gatewayListener{Gateway: gateway, ListenerSectionName: item.SectionName}, routes, item.Hosts, listenerHost)
+				item.Hosts = s.appendHostsFromHTTPRoutes(logger, gatewayListener{Gateway: gateway, ListenerSectionName: item.SectionName}, routes, item.Hosts, listenerHost)
 			}
+			logRoutesWithUnmatchedSection(logger, gateway, routes, listenerSectionNames)
 		}
 
 		return array, nil
 	})
 }
 
-func (s *gatewaySource) appendHostsFromHTTPRoutes(gl gatewayListener, routes []resources.ObjectData, hosts []string, listenerHost string) []string {
+func (s *gatewaySource) appendHostsFromHTTPRoutes(logger logger.LogContext, gl gatewayListener, routes []resources.ObjectData, hosts []string, listenerHost string) []string {
 	addHost := func(hosts []string, host string) []string {
 		for _, h := range hosts {
 			if h == host || shared.MatchesWildcardSingleSubdomain(host, h) {
@@ -135,6 +140,8 @@ func (s *gatewaySource) appendHostsFromHTTPRoutes(gl gatewayListener, routes []r
 		if listenerHost != "" {
 			if !shared.MatchesWildcardAnySubdomain(host, listenerHost) && !shared.MatchesWildcardAnySubdomain(listenerHost, host) {
 				// foreign host for another listener, do not add
+				logger.Debugf("skipping HTTPRoute host %q for gateway %s listener section %q: does not match listener hostname %q",
+					host, gl.Gateway.String(), gl.ListenerSectionName, listenerHost)
 				return hosts
 			}
 		}
@@ -158,6 +165,34 @@ func (s *gatewaySource) appendHostsFromHTTPRoutes(gl gatewayListener, routes []r
 		}
 	}
 	return hosts
+}
+
+// logRoutesWithUnmatchedSection warns about HTTPRoutes that reference the gateway with a
+// listener section name that matches none of the gateway's listeners with a TLS certificate.
+// Their hosts are silently dropped from all certificates, which is otherwise hard to debug.
+func logRoutesWithUnmatchedSection(logger logger.LogContext, gateway resources.ObjectName, routes []resources.ObjectData, listenerSectionNames map[string]struct{}) {
+	warn := func(routeParentRefs []gatewayapisv1.ParentReference, routeName string) {
+		for _, ref := range routeParentRefs {
+			if ref.SectionName == nil {
+				continue
+			}
+			if string(ref.Name) == gateway.Name() &&
+				(ref.Namespace == nil || string(*ref.Namespace) == gateway.Namespace()) {
+				if _, ok := listenerSectionNames[string(*ref.SectionName)]; !ok {
+					logger.Debugf("HTTPRoute %q references listener section name %q of gateway %s that matches no TLS listener; its hosts are ignored",
+						routeName, string(*ref.SectionName), gateway.String())
+				}
+			}
+		}
+	}
+	for _, route := range routes {
+		switch r := route.(type) {
+		case *gatewayapisv1.HTTPRoute:
+			warn(r.Spec.ParentRefs, r.GetName())
+		case *gatewayapisv1beta1.HTTPRoute:
+			warn(r.Spec.ParentRefs, r.GetName())
+		}
+	}
 }
 
 func matchesGatewayListener(parentRefs []gatewayapisv1.ParentReference, gl gatewayListener) bool {

--- a/pkg/controller/source/gateways/gatewayapi/handler_test.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler_test.go
@@ -79,6 +79,55 @@ var _ = Describe("Kubernetes Networking Gateway Handler", func() {
 		}
 		mixedDomainRoutes = []*gatewayapisv1.HTTPRoute{routeExample, routeLegacy}
 
+		routeSectionWeb = &gatewayapisv1.HTTPRoute{
+			Spec: gatewayapisv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+					{
+						Namespace:   ptr.To(gatewayapisv1.Namespace("test")),
+						Name:        "g1",
+						SectionName: ptr.To(gatewayapisv1.SectionName("web")),
+					},
+				}},
+				Hostnames: []gatewayapisv1.Hostname{"api.web.example.com"},
+			},
+		}
+		routeSectionAdmin = &gatewayapisv1.HTTPRoute{
+			Spec: gatewayapisv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+					{
+						Namespace:   ptr.To(gatewayapisv1.Namespace("test")),
+						Name:        "g1",
+						SectionName: ptr.To(gatewayapisv1.SectionName("admin")),
+					},
+				}},
+				Hostnames: []gatewayapisv1.Hostname{"api.admin.example.com"},
+			},
+		}
+		routeSectionGeneric = &gatewayapisv1.HTTPRoute{
+			Spec: gatewayapisv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+					{
+						Namespace:   ptr.To(gatewayapisv1.Namespace("test")),
+						Name:        "g1",
+						SectionName: ptr.To(gatewayapisv1.SectionName("generic")),
+					},
+				}},
+				Hostnames: []gatewayapisv1.Hostname{"api.generic-example.com", "generic-example.com"},
+			},
+		}
+		routeNoSection = &gatewayapisv1.HTTPRoute{
+			Spec: gatewayapisv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapisv1.CommonRouteSpec{ParentRefs: []gatewayapisv1.ParentReference{
+					{
+						Namespace: ptr.To(gatewayapisv1.Namespace("test")),
+						Name:      "g1",
+					},
+				}},
+				Hostnames: []gatewayapisv1.Hostname{"api.shared.example.com"},
+			},
+		}
+		sectionRoutes = []*gatewayapisv1.HTTPRoute{routeSectionWeb, routeSectionAdmin, routeSectionGeneric, routeNoSection}
+
 		log                = logger.NewContext("", "TestEnv")
 		emptyMap           = map[types.NamespacedName]source.CertInfo{}
 		standardObjectMeta = metav1.ObjectMeta{
@@ -396,6 +445,63 @@ var _ = Describe("Kubernetes Networking Gateway Handler", func() {
 				},
 			},
 		}, routes, singleCertInfo("cert-example", nil, "foo.example.com", "bar.example.com")),
+		Entry("HTTPRoutes with section name should only add hosts to the matching listener", &gatewayapisv1.Gateway{
+			ObjectMeta: standardObjectMeta,
+			Spec: gatewayapisv1.GatewaySpec{
+				Listeners: []gatewayapisv1.Listener{
+					{
+						Name:     "web",
+						Hostname: ptr.To(gatewayapisv1.Hostname("*.example.com")),
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-web"}},
+						},
+					},
+					{
+						Name:     "admin",
+						Hostname: ptr.To(gatewayapisv1.Hostname("*.example.com")),
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-admin"}},
+						},
+					},
+					{
+						Name:     "generic",
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-generic"}},
+						},
+					},
+				},
+			},
+		}, sectionRoutes, toMap(
+			makeCertInfo("cert-web", nil, "*.example.com", "api.web.example.com", "api.shared.example.com"),
+			makeCertInfo("cert-admin", nil, "*.example.com", "api.admin.example.com", "api.shared.example.com"),
+			makeCertInfo("cert-generic", nil, "api.generic-example.com", "generic-example.com", "api.shared.example.com"),
+		)),
+		Entry("listeners with different section names sharing one certificate secret should merge their hosts", &gatewayapisv1.Gateway{
+			ObjectMeta: standardObjectMeta,
+			Spec: gatewayapisv1.GatewaySpec{
+				Listeners: []gatewayapisv1.Listener{
+					{
+						Name:     "web",
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-shared"}},
+						},
+					},
+					{
+						Name:     "admin",
+						Protocol: gatewayapisv1.HTTPSProtocolType,
+						TLS: &gatewayapisv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayapisv1.SecretObjectReference{{Name: "cert-shared"}},
+						},
+					},
+				},
+			},
+		}, sectionRoutes, toMap(
+			makeCertInfo("cert-shared", nil, "api.web.example.com", "api.shared.example.com", "api.admin.example.com"),
+		)),
 	)
 })
 
@@ -408,9 +514,17 @@ var _ httpRouteLister = &testRouteLister{}
 func (t testRouteLister) ListHTTPRoutes(gateway *resources.ObjectName) ([]resources.ObjectData, error) {
 	var filtered []resources.ObjectData
 	for _, r := range t.routes {
-		for _, ref := range r.Spec.ParentRefs {
-			if gateway == nil ||
-				(ref.Namespace == nil || string(*ref.Namespace) == (*gateway).Namespace()) && string(ref.Name) == (*gateway).Name() {
+		if gateway != nil {
+			gw := *gateway
+			for _, ref := range r.Spec.ParentRefs {
+				if gw.Name() == string(ref.Name) &&
+					(ref.Namespace == nil || string(*ref.Namespace) == gw.Namespace()) {
+					filtered = append(filtered, r)
+					break
+				}
+			}
+		} else {
+			if len(r.Spec.ParentRefs) > 0 {
 				filtered = append(filtered, r)
 			}
 		}

--- a/pkg/controller/source/gateways/gatewayapi/httproutesReconciler.go
+++ b/pkg/controller/source/gateways/gatewayapi/httproutesReconciler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	"k8s.io/utils/ptr"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -58,6 +59,14 @@ func (r *httproutesReconciler) triggerGateways(cluster string, gateways resource
 
 func extractGatewayNames(route resources.ObjectData) resources.ObjectNameSet {
 	gatewayNames := resources.NewObjectNameSet()
+	for _, item := range extractGatewayListeners(route) {
+		gatewayNames.Add(item.Gateway)
+	}
+	return gatewayNames
+}
+
+func extractGatewayListeners(route resources.ObjectData) []gatewayListener {
+	var gatewayListeners []gatewayListener
 	switch data := route.(type) {
 	case *gatewayapisv1.HTTPRoute:
 		for _, ref := range data.Spec.ParentRefs {
@@ -67,7 +76,10 @@ func extractGatewayNames(route resources.ObjectData) resources.ObjectNameSet {
 				if ref.Namespace != nil {
 					namespace = string(*ref.Namespace)
 				}
-				gatewayNames.Add(resources.NewObjectName(namespace, string(ref.Name)))
+				gatewayListeners = append(gatewayListeners, gatewayListener{
+					Gateway:             resources.NewObjectName(namespace, string(ref.Name)),
+					ListenerSectionName: string(ptr.Deref(ref.SectionName, "")),
+				})
 			}
 		}
 	case *gatewayapisv1beta1.HTTPRoute:
@@ -78,9 +90,12 @@ func extractGatewayNames(route resources.ObjectData) resources.ObjectNameSet {
 				if ref.Namespace != nil {
 					namespace = string(*ref.Namespace)
 				}
-				gatewayNames.Add(resources.NewObjectName(namespace, string(ref.Name)))
+				gatewayListeners = append(gatewayListeners, gatewayListener{
+					Gateway:             resources.NewObjectName(namespace, string(ref.Name)),
+					ListenerSectionName: string(ptr.Deref(ref.SectionName, "")),
+				})
 			}
 		}
 	}
-	return gatewayNames
+	return gatewayListeners
 }

--- a/pkg/controller/source/gateways/gatewayapi/state.go
+++ b/pkg/controller/source/gateways/gatewayapi/state.go
@@ -14,6 +14,13 @@ import (
 
 var stateKey = ctxutil.SimpleKey("gatewayapi-gateways-state")
 
+// gatewayListener identifies a specific listener section within a Gateway resource.
+type gatewayListener struct {
+	Gateway resources.ObjectName
+	// ListenerSectionName is an optional field to specify a listener of the gateway.
+	ListenerSectionName string
+}
+
 type routesState struct {
 	lock sync.Mutex
 

--- a/pkg/controller/source/helper.go
+++ b/pkg/controller/source/helper.go
@@ -39,6 +39,7 @@ type TLSData struct {
 	SecretNamespace *string
 	SecretName      string
 	Hosts           []string
+	SectionName     string
 }
 
 // GetCertsInfoByCollector collects data from annotations and from the resources needed for creating certificates.
@@ -112,6 +113,14 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 		if tls.SecretNamespace != nil {
 			secretName.Namespace = *tls.SecretNamespace
 		}
+		if existing, ok := info.Certs[secretName]; ok {
+			// Multiple listeners may reference the same certificate secret (e.g. distinct
+			// listener section names sharing one certificateRef). Merge their domains instead
+			// of overwriting, so no host is silently dropped.
+			existing.Domains = mergeDomainLists(existing.Domains, domains)
+			info.Certs[secretName] = existing
+			continue
+		}
 		info.Certs[secretName] = source.CertInfo{
 			SecretName:          secretName,
 			Domains:             domains,
@@ -127,6 +136,21 @@ func GetCertsInfoByCollector(logger logger.LogContext, objData resources.ObjectD
 		}
 	}
 	return info, err
+}
+
+// mergeDomainLists appends domains from add that are not already present in base, preserving order.
+func mergeDomainLists(base, add []string) []string {
+	seen := make(map[string]struct{}, len(base))
+	for _, d := range base {
+		seen[d] = struct{}{}
+	}
+	for _, d := range add {
+		if _, ok := seen[d]; !ok {
+			seen[d] = struct{}{}
+			base = append(base, d)
+		}
+	}
+	return base
 }
 
 func mergeCommonName(cn string, hosts []string) []string {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

HTTPRoutes may pin to a specific Gateway listener via ParentRef.SectionName.
Previously, hosts from all HTTPRoutes referencing a Gateway were added to
every listener's certificate, polluting SANs across listeners.

Track the listener section name per route (GatewayListener) and, when
collecting certificate hosts, only add an HTTPRoute's hostnames to the
listener it targets. Routes without a section name still contribute to all
listeners of the Gateway.

Extends the GetCertsInfo table test with a multi-listener, section-pinned
scenario.

Also implemented for the source controllers of certman2.

**Which issue(s) this PR fixes**:
Fixes #659 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
[k8s gateway source controllers] Assign HTTPRoute hosts to matching listener by section name.
```
